### PR TITLE
security: enforce spec loading from default branch only

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ export default (app) => {
   async function evaluateAndCreateCheck(context, pull_request) {
     const startTime = new Date();
     try {
-      const { spec, source } = await loadRepoSpec(context, pull_request.head.sha);
+      const { spec, source } = await loadRepoSpec(context);
       console.log(`📄 Spec loaded from ${source} for PR #${pull_request.number}`);
 
       const runResult = await runAllGates(context, pull_request, spec);

--- a/test/integration/cogni-evaluated-gates-behavior.test.js
+++ b/test/integration/cogni-evaluated-gates-behavior.test.js
@@ -82,7 +82,7 @@ describe('Cogni Evaluated Gates Behavior Contract Tests', () => {
         permissions: { checks: "write", pull_requests: "read", metadata: "read" }
       })
       .get('/repos/test-org/test-repo/contents/.cogni%2Frepo-spec.yaml')
-      .query({ ref: "abc123def456789012345678901234567890abcd" })
+      .query({ ref: "main" })
       .reply(404, { message: 'Not Found' })
       .post('/repos/test-org/test-repo/check-runs', (body) => {
         // Verify behavior contract: missing spec now blocks merges
@@ -113,7 +113,7 @@ describe('Cogni Evaluated Gates Behavior Contract Tests', () => {
         permissions: { checks: "write", pull_requests: "read", metadata: "read" }
       })
       .get('/repos/test-org/test-repo/contents/.cogni%2Frepo-spec.yaml')
-      .query({ ref: "abc123def456789012345678901234567890abcd" })
+      .query({ ref: "main" })
       .reply(200, {
         type: "file",
         content: Buffer.from(specYAML).toString('base64'),
@@ -154,7 +154,7 @@ describe('Cogni Evaluated Gates Behavior Contract Tests', () => {
         permissions: { checks: "write", pull_requests: "read", metadata: "read" }
       })
       .get('/repos/test-org/test-repo/contents/.cogni%2Frepo-spec.yaml')
-      .query({ ref: "abc123def456789012345678901234567890abcd" })
+      .query({ ref: "main" })
       .reply(200, {
         type: "file",
         content: Buffer.from(specYAML).toString('base64'),
@@ -195,7 +195,7 @@ describe('Cogni Evaluated Gates Behavior Contract Tests', () => {
         permissions: { checks: "write", pull_requests: "read", metadata: "read" }
       })
       .get('/repos/test-org/test-repo/contents/.cogni%2Frepo-spec.yaml')
-      .query({ ref: "abc123def456789012345678901234567890abcd" })
+      .query({ ref: "main" })
       .reply(200, {
         type: "file",
         content: Buffer.from(specYAML).toString('base64'),

--- a/test/integration/simple-integration.test.js
+++ b/test/integration/simple-integration.test.js
@@ -60,7 +60,7 @@ describe("Simple Integration Tests", () => {
       })
       // Mock spec file fetch - return minimal spec
       .get("/repos/derekg1729/cogni-git-review/contents/.cogni%2Frepo-spec.yaml")
-      .query({ ref: "abc123def456789012345678901234567890abcd" })
+      .query({ ref: "main" })
       .reply(200, {
         type: "file",
         content: Buffer.from(SPEC_FIXTURES.minimal).toString('base64'),
@@ -105,7 +105,7 @@ describe("Simple Integration Tests", () => {
       })
       // Mock spec file fetch - return 404
       .get("/repos/derekg1729/cogni-git-review/contents/.cogni%2Frepo-spec.yaml")
-      .query({ ref: "abc123def456789012345678901234567890abcd" })
+      .query({ ref: "main" })
       .reply(404, { message: "Not Found" })
       // Mock check run creation - should be failure (missing spec)
       .post("/repos/derekg1729/cogni-git-review/check-runs", (body) => {

--- a/test/integration/spec-aware-webhook.test.js
+++ b/test/integration/spec-aware-webhook.test.js
@@ -63,7 +63,7 @@ describe("Spec-Aware Webhook Integration Tests", () => {
       })
       // Mock spec file fetch - return 404
       .get("/repos/derekg1729/cogni-git-review/contents/.cogni%2Frepo-spec.yaml")
-      .query({ ref: "abc123def456789012345678901234567890abcd" })
+      .query({ ref: "main" })
       .reply(404, { message: "Not Found" })
       // Mock check run creation
       .post("/repos/derekg1729/cogni-git-review/check-runs", (body) => {
@@ -105,7 +105,7 @@ describe("Spec-Aware Webhook Integration Tests", () => {
       })
       // Mock spec file fetch - return invalid YAML
       .get("/repos/derekg1729/cogni-git-review/contents/.cogni%2Frepo-spec.yaml")
-      .query({ ref: "abc123def456789012345678901234567890abcd" })
+      .query({ ref: "main" })
       .reply(200, {
         type: "file",
         content: Buffer.from(invalidSpec).toString('base64'),
@@ -151,7 +151,7 @@ describe("Spec-Aware Webhook Integration Tests", () => {
       })
       // Mock spec file fetch
       .get("/repos/derekg1729/cogni-git-review/contents/.cogni%2Frepo-spec.yaml")
-      .query({ ref: "abc123def456789012345678901234567890abcd" })
+      .query({ ref: "main" })
       .reply(200, {
         type: "file",
         content: Buffer.from(minimalSpec).toString('base64'),
@@ -204,7 +204,7 @@ gates:
       })
       // Mock spec file fetch - should only happen once due to caching
       .get("/repos/derekg1729/cogni-git-review/contents/.cogni%2Frepo-spec.yaml")
-      .query({ ref: "abc123def456789012345678901234567890abcd" })
+      .query({ ref: "main" })
       .once() // Important: only once due to caching
       .reply(200, {
         type: "file",

--- a/test/mock-integration/webhook-handlers.test.js
+++ b/test/mock-integration/webhook-handlers.test.js
@@ -62,7 +62,7 @@ describe("GitHub Webhook Handler Mock-Integration Tests", () => {
       })
       // Mock missing spec file
       .get("/repos/derekg1729/cogni-git-review/contents/.cogni%2Frepo-spec.yaml")
-      .query({ ref: "abc123def456789012345678901234567890abcd" })
+      .query({ ref: "main" })
       .reply(404, { message: "Not Found" })
       .post("/repos/derekg1729/cogni-git-review/check-runs", (body) => {
         // Verify the check run creation matches our expected structure (no spec = failure)
@@ -99,7 +99,7 @@ describe("GitHub Webhook Handler Mock-Integration Tests", () => {
       })
       // Mock missing spec file
       .get("/repos/derekg1729/cogni-git-review/contents/.cogni%2Frepo-spec.yaml")
-      .query({ ref: "def456789012345678901234567890abcdef1235" })
+      .query({ ref: "main" })
       .reply(404, { message: "Not Found" })
       .post("/repos/derekg1729/cogni-git-review/check-runs", (body) => {
         // Verify the check run for synchronize event (no spec = failure)
@@ -136,7 +136,7 @@ describe("GitHub Webhook Handler Mock-Integration Tests", () => {
       })
       // Mock spec loading
       .get("/repos/derekg1729/cogni-git-review/contents/.cogni%2Frepo-spec.yaml")
-      .query({ ref: "abc123def456789012345678901234567890abcd" })
+      .query({ ref: "main" })
       .reply(200, {
         type: "file",
         content: Buffer.from(SPEC_FIXTURES.minimal).toString('base64'),


### PR DESCRIPTION

<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/9e90cac5-0deb-4077-8de2-18cd517b38c9" />


BREAKING CHANGE: Remove SHA parameter from loadRepoSpec() to prevent PRs from modifying their own validation rules.

Security fixes:
- Always load repo-spec from repository's default branch
- Remove vulnerable SHA parameter from loadRepoSpec(context, sha)
- Update cache keys to use default branch instead of PR branch
- Add validation for missing default_branch in payload

Implementation changes:
- src/spec-loader.js: Use context.payload.repository.default_branch
- index.js: Remove pull_request.head.sha parameter
- All tests: Update mocks to expect default branch refs

Test coverage:
- 3 new security-focused unit tests
- All integration tests updated and passing
- 43/44 tests pass (1 skipped, 0 failures)

Resolves critical P0 security vulnerability where PRs could bypass validation by including modified repo-spec files.