### PR TITLE
feat: migrate repo-spec format from enable array to single rule_file

### DIFF
--- a/.cogni/repo-spec-template.yaml
+++ b/.cogni/repo-spec-template.yaml
@@ -1,7 +1,7 @@
 # Cogni Git Review Repository Specification Template
 # Copy this file to .cogni/repo-spec.yaml and customize for your repository
 
-schema_version: '0.1.2'
+schema_version: '0.1.3'
 
 intent:
   name: my-project
@@ -17,6 +17,10 @@ gates:
     with:
       max_changed_files: 30
       max_total_diff_kb: 100
+    
+  - id: rules
+    with:
+      rule_file: goal-alignment.yaml
 
   # - id: goal_declaration
   # - id: forbidden_scopes

--- a/.cogni/repo-spec.yaml
+++ b/.cogni/repo-spec.yaml
@@ -1,4 +1,4 @@
-schema_version: '0.1.2'
+schema_version: '0.1.3'
 
 intent:
   name: cogni-git-review
@@ -29,5 +29,4 @@ gates:
   - id: forbidden_scopes
   - id: rules
     with:
-      rules_dir: .cogni/rules
-      enable: [goal-alignment.yaml]
+      rule_file: goal-alignment.yaml

--- a/.cogni/rules/goal-alignment.yaml
+++ b/.cogni/rules/goal-alignment.yaml
@@ -1,9 +1,35 @@
 id: goal-alignment
-schema_version: '0.1'
+schema_version: "0.1"
 blocking: true
 
 prompt:
-  template: .cogni/prompts/goal-alignment.md
+  # MVP: inline prompt text, no separate .md fetch needed
+  inline: |
+    # Goal Alignment Evaluation
+
+    You are evaluating whether a pull request aligns with the repository's stated goals and avoids its non-goals.
+
+    ## Repository Context
+    **Goals**: {{goals}}
+    **Non-Goals**: {{non_goals}}
+
+    ## Pull Request to Evaluate
+    **Title**: {{pr_title}}
+    **Description**: {{pr_body}}
+    **Changes Summary**: {{diff_summary}}
+
+    ## Required Output Format
+    Return ONLY this JSON object:
+    {
+      "score": 0.85,
+      "violations": [],
+      "summary": "Brief assessment of goal alignment"
+    }
+
+    - The "score" must be a number between 0 and 1.
+    - Use temperature=0. Do not include extra text.
+
+  # Optional; if omitted, provider uses the default full set below
   variables: [goals, non_goals, pr_title, pr_body, diff_summary]
 
 success_criteria:


### PR DESCRIPTION

<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/b7fcaf68-bfe6-4b95-8653-3fee00a1d7bb" />


## Summary
- Updates `.cogni/repo-spec.yaml` from `enable: [goal-alignment.yaml]` to `rule_file: goal-alignment.yaml`
- Update `.cogni/rules/goal-alignment.yaml` to have inline prompt. still mvp, expect updates in next pr
- Updates `.cogni/repo-spec-template.yaml` to include rules gate example with new format
- Increments template schema version to 0.1.3

## Rationale
Aligns configuration format with single-rule-per-gate MVP architecture. The new `rule_file` format is cleaner and matches the current implementation where each rules gate loads exactly one rule file.

Enable easy testing, via spec + rule pulled from main. We need a more robust testing setup :) 