### PR TITLE
New Gate: require relevant AGENTS.md documentation

### DIFF
--- a/.cogni/repo-spec-template.yaml
+++ b/.cogni/repo-spec-template.yaml
@@ -18,6 +18,13 @@ gates:
     with:
       max_changed_files: 30
       max_total_diff_kb: 100
+
+  # Ensure AGENTS.md files are updated when code changes
+  - type: agents-md-sync
+    id: agents_md_sync
+    # with:  # Optional configuration
+    #   code_patterns: ["src/**/*.js", "lib/**/*.ts"]  # Files that require doc updates
+    #   doc_pattern: "AGENTS.md"                       # Documentation file to check
     
   - type: ai-rule
     with:

--- a/.cogni/repo-spec.yaml
+++ b/.cogni/repo-spec.yaml
@@ -30,6 +30,9 @@ gates:
     id: goal_declaration
   - type: forbidden-scopes
     id: forbidden_scopes
+  # Ensure AGENTS.md files are updated when code changes
+  - type: agents-md-sync
+    id: agents_md_sync
   - type: ai-rule
     with:
       rule_file: dont-rebuild-oss.yaml

--- a/src/gates/cogni/AGENTS.md
+++ b/src/gates/cogni/AGENTS.md
@@ -11,6 +11,7 @@ Gates are implemented by cogni-git-review. The .cogni/repo-spec.yml in a reposit
 - **review-limits**: File count and diff size validation
 - **goal-declaration**: Repository goals validation
 - **forbidden-scopes**: Repository non-goals validation  
+- **agents-md-sync**: Ensures AGENTS.md files are updated when code changes
 - **ai-rule**: AI-powered evaluation using declarative rules (supports multiple instances)
 
 ## Gate Implementation Pattern
@@ -26,6 +27,25 @@ export async function run(context, gateConfig) {
     duration_ms: 123
   };
 }
+```
+
+## AGENTS.md Sync Gate
+The `agents-md-sync` gate enforces documentation synchronization:
+- Analyzes PR file changes using GitHub API (`context.octokit.pulls.listFiles`)
+- When code files change in a directory, requires corresponding `AGENTS.md` to be updated
+- Configurable code patterns (default: `**/*.*`) and doc pattern (default: `AGENTS.md`)
+- Uses `micromatch` library for robust glob pattern matching
+- Excludes documentation files (.md, README, CHANGELOG) from triggering violations
+- Returns neutral status on GitHub API errors to avoid blocking PRs
+
+Configuration example:
+```yaml
+gates:
+  - type: agents-md-sync
+    id: agents_md_sync
+    with:
+      code_patterns: ["src/**/*.js", "lib/**/*.ts"]  # Optional
+      doc_pattern: "AGENTS.md"                       # Optional
 ```
 
 ## AI Rule Gate

--- a/src/gates/cogni/agents-md-sync.js
+++ b/src/gates/cogni/agents-md-sync.js
@@ -1,0 +1,95 @@
+/**
+ * AGENTS.md Synchronization Gate - Ensures documentation updates with code changes
+ * Part of Cogni Gate Evaluation system
+ */
+
+import path from 'node:path';
+import micromatch from 'micromatch';
+
+// Gate registry contract exports
+export const type = 'agents-md-sync';
+
+/**
+ * Registry-compatible run function for agents-sync gate
+ * @param {object} ctx - Run context with octokit, pr, etc.
+ * @param {object} gate - Gate configuration from spec
+ * @returns {Promise<object>} Normalized gate result
+ */
+export async function run(ctx, gate) {
+  try {
+    // Get configuration with defaults
+    const config = gate.with || {};
+    const codePatterns = config.code_patterns || ['**/*.*'];
+    const docPattern = config.doc_pattern || 'AGENTS.md';
+
+    // Get changed files from GitHub API
+    const { data: changedFiles } = await ctx.octokit.pulls.listFiles(
+      ctx.repo({ pull_number: ctx.pr.number })
+    );
+
+    // Filter for code changes (exclude documentation files and removed files)
+    const codeChanges = changedFiles.filter(file => {
+      // Skip removed files
+      if (file.status === 'removed') return false;
+      
+      // Skip documentation files
+      if (file.filename.endsWith(docPattern)) return false;
+      if (file.filename.includes('README') || file.filename.includes('CHANGELOG')) return false;
+      if (file.filename.endsWith('.md')) return false;
+      
+      // Check if file matches any code pattern using proper glob matching
+      return codePatterns.some(pattern => micromatch.isMatch(file.filename, pattern));
+    });
+
+    // For each code change, check if corresponding AGENTS.md was updated
+    const violations = [];
+    const checkedDirs = new Set(); // Avoid duplicate checks for same directory
+
+    for (const file of codeChanges) {
+      const fileDir = path.dirname(file.filename);
+      
+      // Skip if we already checked this directory
+      if (checkedDirs.has(fileDir)) continue;
+      checkedDirs.add(fileDir);
+
+      const expectedDocPath = path.join(fileDir, docPattern);
+      
+      // Check if the expected documentation file was updated
+      const docUpdated = changedFiles.some(f => f.filename === expectedDocPath);
+      
+      if (!docUpdated) {
+        violations.push({
+          code: 'MISSING_AGENTS_UPDATE',
+          message: `Code changes in ${fileDir}/ but ${expectedDocPath} not updated`,
+          path: file.filename,
+          meta: { 
+            expected_doc_path: expectedDocPath,
+            changed_file: file.filename,
+            directory: fileDir
+          }
+        });
+      }
+    }
+
+    // Return gate result
+    return {
+      status: violations.length > 0 ? 'fail' : 'pass',
+      violations,
+      stats: {
+        total_changed_files: changedFiles.length,
+        code_changes_found: codeChanges.length,
+        directories_checked: checkedDirs.size,
+        violations_found: violations.length
+      }
+    };
+
+  } catch (error) {
+    // If GitHub API fails, return neutral so PR isn't blocked
+    return {
+      status: 'neutral',
+      neutral_reason: 'api_error',
+      violations: [],
+      stats: { error: error.message }
+    };
+  }
+}

--- a/test/contract/agents-sync-integration.test.js
+++ b/test/contract/agents-sync-integration.test.js
@@ -1,0 +1,230 @@
+/**
+ * AGENTS.md Synchronization Gate Integration Tests
+ * Tests the gate within the launcher framework with real-world scenarios
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+import { runConfiguredGates } from '../../src/gates/run-configured.js';
+import yaml from 'js-yaml';
+
+describe('AGENTS.md Sync Gate Integration Tests', () => {
+
+  function createTestSpec(gateConfig = {}) {
+    return {
+      schema_version: '0.1.4',
+      intent: {
+        name: 'agents-md-sync-test-project',
+        goals: ['Test AGENTS.md synchronization'],
+        non_goals: ['Missing documentation']
+      },
+      gates: [
+        {
+          type: 'agents-md-sync',
+          id: 'agents_sync',
+          with: gateConfig
+        }
+      ]
+    };
+  }
+
+  function createRunContext(changedFiles, spec = createTestSpec()) {
+    return {
+      spec,
+      pr: { 
+        number: 123,
+        changed_files: changedFiles.length,
+        additions: 50,
+        deletions: 10
+      },
+      repo: () => ({ owner: 'test-org', repo: 'test-repo' }),
+      octokit: {
+        pulls: {
+          listFiles: async () => ({ data: changedFiles })
+        }
+      },
+      logger: (level, msg, meta) => console.log(`[${level}] ${msg}`, meta || ''),
+      abort: new AbortController().signal
+    };
+  }
+
+  test('gate fails when code changes lack AGENTS.md updates', async () => {
+    const changedFiles = [
+      { filename: 'src/auth/oauth.js', status: 'added' },
+      { filename: 'src/auth/utils.js', status: 'modified' }
+    ];
+
+    const runCtx = createRunContext(changedFiles);
+    const launcherResult = await runConfiguredGates(runCtx);
+    const results = launcherResult.results;
+
+    assert.strictEqual(results.length, 1);
+    const gateResult = results[0];
+    
+    assert.strictEqual(gateResult.id, 'agents_sync');
+    assert.strictEqual(gateResult.status, 'fail');
+    assert.strictEqual(gateResult.violations.length, 1);
+    assert.strictEqual(gateResult.violations[0].code, 'MISSING_AGENTS_UPDATE');
+    assert(gateResult.violations[0].message.includes('src/auth/AGENTS.md'));
+    assert(typeof gateResult.duration_ms === 'number');
+  });
+
+  test('gate passes when code changes include AGENTS.md updates', async () => {
+    const changedFiles = [
+      { filename: 'src/gates/new-gate.js', status: 'added' },
+      { filename: 'src/gates/AGENTS.md', status: 'modified' },
+      { filename: 'test/unit/new-gate.test.js', status: 'added' },
+      { filename: 'test/unit/AGENTS.md', status: 'modified' }
+    ];
+
+    const runCtx = createRunContext(changedFiles);
+    const launcherResult = await runConfiguredGates(runCtx);
+    const results = launcherResult.results;
+
+    assert.strictEqual(results.length, 1);
+    const gateResult = results[0];
+    
+    assert.strictEqual(gateResult.id, 'agents_sync');
+    assert.strictEqual(gateResult.status, 'pass');
+    assert.strictEqual(gateResult.violations.length, 0);
+    assert(gateResult.stats.code_changes_found > 0);
+    assert(gateResult.stats.directories_checked >= 1);
+  });
+
+  test('gate passes when only documentation files are changed', async () => {
+    const changedFiles = [
+      { filename: 'README.md', status: 'modified' },
+      { filename: 'docs/setup.md', status: 'added' },
+      { filename: 'CHANGELOG.md', status: 'modified' }
+    ];
+
+    const runCtx = createRunContext(changedFiles);
+    const launcherResult = await runConfiguredGates(runCtx);
+    const results = launcherResult.results;
+
+    assert.strictEqual(results.length, 1);
+    const gateResult = results[0];
+    
+    assert.strictEqual(gateResult.id, 'agents_sync');
+    assert.strictEqual(gateResult.status, 'pass');
+    assert.strictEqual(gateResult.violations.length, 0);
+    assert.strictEqual(gateResult.stats.code_changes_found, 0);
+  });
+
+  test('gate handles custom configuration correctly', async () => {
+    const customConfig = {
+      code_patterns: ['custom/**/*.py', 'scripts/*.sh'],
+      doc_pattern: 'DOCUMENTATION.md'
+    };
+
+    const changedFiles = [
+      { filename: 'custom/module.py', status: 'added' },
+      { filename: 'custom/DOCUMENTATION.md', status: 'modified' }
+    ];
+
+    const spec = createTestSpec(customConfig);
+    const runCtx = createRunContext(changedFiles, spec);
+    const launcherResult = await runConfiguredGates(runCtx);
+    const results = launcherResult.results;
+
+    assert.strictEqual(results.length, 1);
+    const gateResult = results[0];
+    
+    assert.strictEqual(gateResult.status, 'pass');
+    assert.strictEqual(gateResult.violations.length, 0);
+  });
+
+  test('gate handles multiple directory violations', async () => {
+    const changedFiles = [
+      { filename: 'src/auth/oauth.js', status: 'added' },
+      { filename: 'src/gates/new-gate.js', status: 'added' },
+      { filename: 'lib/utils.js', status: 'modified' }
+      // No AGENTS.md updates in any directory
+    ];
+
+    const runCtx = createRunContext(changedFiles);
+    const launcherResult = await runConfiguredGates(runCtx);
+    const results = launcherResult.results;
+
+    assert.strictEqual(results.length, 1);
+    const gateResult = results[0];
+    
+    assert.strictEqual(gateResult.status, 'fail');
+    assert.strictEqual(gateResult.violations.length, 3); // One per directory
+    assert.strictEqual(gateResult.stats.directories_checked, 3);
+    
+    const expectedPaths = ['src/auth/AGENTS.md', 'src/gates/AGENTS.md', 'lib/AGENTS.md'];
+    const actualPaths = gateResult.violations.map(v => v.meta.expected_doc_path);
+    
+    for (const expectedPath of expectedPaths) {
+      assert(actualPaths.includes(expectedPath), `Should include ${expectedPath}`);
+    }
+  });
+
+  test('gate returns neutral on GitHub API errors', async () => {
+    const runCtx = {
+      spec: createTestSpec(),
+      pr: { number: 123, changed_files: 1 },
+      repo: () => ({ owner: 'test-org', repo: 'test-repo' }),
+      octokit: {
+        pulls: {
+          listFiles: async () => {
+            throw new Error('GitHub API rate limit');
+          }
+        }
+      },
+      logger: (level, msg, meta) => console.log(`[${level}] ${msg}`, meta || ''),
+      abort: new AbortController().signal
+    };
+
+    const launcherResult = await runConfiguredGates(runCtx);
+    const results = launcherResult.results;
+
+    assert.strictEqual(results.length, 1);
+    const gateResult = results[0];
+    
+    assert.strictEqual(gateResult.id, 'agents_sync');
+    assert.strictEqual(gateResult.status, 'neutral');
+    assert.strictEqual(gateResult.neutral_reason, 'api_error');
+    assert.strictEqual(gateResult.violations.length, 0);
+    assert(gateResult.stats.error.includes('GitHub API rate limit'));
+  });
+
+  test('gate integrates with timeout handling', async () => {
+    const changedFiles = [
+      { filename: 'src/module.js', status: 'added' }
+    ];
+
+    // Create pre-aborted signal to simulate timeout
+    const abortController = new AbortController();
+    abortController.abort();
+
+    const runCtx = createRunContext(changedFiles);
+    runCtx.abort = abortController.signal;
+
+    const launcherResult = await runConfiguredGates(runCtx);
+    const results = launcherResult.results;
+
+    // Should return empty results due to timeout before gate execution
+    assert.strictEqual(results.length, 0);
+  });
+
+  test('gate ID normalization works correctly', async () => {
+    const changedFiles = [
+      { filename: 'src/module.js', status: 'added' }
+    ];
+
+    const runCtx = createRunContext(changedFiles);
+    const launcherResult = await runConfiguredGates(runCtx);
+    const results = launcherResult.results;
+
+    assert.strictEqual(results.length, 1);
+    const gateResult = results[0];
+    
+    // ID should be normalized to spec configuration
+    assert.strictEqual(gateResult.id, 'agents_sync');
+    assert(gateResult.hasOwnProperty('duration_ms'));
+    assert(Array.isArray(gateResult.violations));
+    assert(typeof gateResult.stats === 'object');
+  });
+});

--- a/test/fixtures/repo-specs.js
+++ b/test/fixtures/repo-specs.js
@@ -330,7 +330,58 @@ gates:
       rule_file: dont-rebuild-oss.yaml
   - type: ai-rule
     with:
-      rule_file: single-check-pr-verdict.yaml`
+      rule_file: single-check-pr-verdict.yaml`,
+
+  // AGENTS.md Synchronization Gate Test Fixtures
+  agentsSync: `schema_version: '0.1.4'
+
+intent:
+  name: agents-md-sync-test-project
+  goals:
+    - Maintain synchronized AGENTS.md documentation
+    - Ensure code changes include documentation updates
+  non_goals:
+    - Allowing undocumented code changes
+
+gates:
+  - type: agents-md-sync
+    id: agents_sync`,
+
+  agentsSyncWithCustomConfig: `schema_version: '0.1.4'
+
+intent:
+  name: agents-sync-custom-test-project
+  goals:
+    - Test custom patterns for AGENTS.md synchronization
+  non_goals:
+    - Default file patterns
+
+gates:
+  - type: agents-md-sync
+    id: agents_sync
+    with:
+      code_patterns: ["custom/**/*.py", "scripts/*.sh"]
+      doc_pattern: "DOCUMENTATION.md"`,
+
+  agentsSyncWithOtherGates: `schema_version: '0.1.4'
+
+intent:
+  name: agents-sync-combined-test-project
+  goals:
+    - Test AGENTS.md sync with other quality gates
+  non_goals:
+    - Single gate testing
+
+gates:
+  - type: review-limits
+    id: review_limits
+    with:
+      max_changed_files: 30
+      max_total_diff_kb: 100
+  - type: agents-md-sync
+    id: agents_sync
+  - type: goal-declaration
+    id: goal_declaration`
 };
 
 // Helper for accessing specs by key  

--- a/test/unit/agents-sync.test.js
+++ b/test/unit/agents-sync.test.js
@@ -1,0 +1,268 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+import { run } from '../../src/gates/cogni/agents-md-sync.js';
+
+describe('AGENTS.md Synchronization Gate', () => {
+  
+  function createMockContext(changedFiles) {
+    return {
+      pr: { number: 123 },
+      repo: () => ({ owner: 'test-org', repo: 'test-repo' }),
+      octokit: {
+        pulls: {
+          listFiles: async () => ({ data: changedFiles })
+        }
+      }
+    };
+  }
+
+  test('passes when no code files are changed', async () => {
+    const changedFiles = [
+      { filename: 'README.md', status: 'modified' },
+      { filename: 'docs/setup.md', status: 'added' }
+    ];
+    
+    const ctx = createMockContext(changedFiles);
+    const result = await run(ctx, {});
+
+    assert.strictEqual(result.status, 'pass');
+    assert.strictEqual(result.violations.length, 0);
+    assert.strictEqual(result.stats.code_changes_found, 0);
+  });
+
+  test('fails when code file changed but AGENTS.md not updated', async () => {
+    const changedFiles = [
+      { filename: 'src/auth/oauth.js', status: 'added' },
+      { filename: 'src/auth/utils.js', status: 'modified' }
+    ];
+    
+    const ctx = createMockContext(changedFiles);
+    const result = await run(ctx, {});
+
+    assert.strictEqual(result.status, 'fail');
+    assert.strictEqual(result.violations.length, 1);
+    assert.strictEqual(result.violations[0].code, 'MISSING_AGENTS_UPDATE');
+    assert.strictEqual(result.violations[0].meta.expected_doc_path, 'src/auth/AGENTS.md');
+    assert.strictEqual(result.stats.code_changes_found, 2);
+    assert.strictEqual(result.stats.directories_checked, 1);
+  });
+
+  test('passes when code file changed and AGENTS.md updated', async () => {
+    const changedFiles = [
+      { filename: 'src/auth/oauth.js', status: 'added' },
+      { filename: 'src/auth/AGENTS.md', status: 'modified' }
+    ];
+    
+    const ctx = createMockContext(changedFiles);
+    const result = await run(ctx, {});
+
+    assert.strictEqual(result.status, 'pass');
+    assert.strictEqual(result.violations.length, 0);
+    assert.strictEqual(result.stats.code_changes_found, 1);
+    assert.strictEqual(result.stats.directories_checked, 1);
+  });
+
+  test('handles multiple directories correctly', async () => {
+    const changedFiles = [
+      { filename: 'src/auth/oauth.js', status: 'added' },
+      { filename: 'src/gates/new-gate.js', status: 'added' },
+      { filename: 'src/auth/AGENTS.md', status: 'modified' }
+      // Missing src/gates/AGENTS.md
+    ];
+    
+    const ctx = createMockContext(changedFiles);
+    const result = await run(ctx, {});
+
+    assert.strictEqual(result.status, 'fail');
+    assert.strictEqual(result.violations.length, 1);
+    assert.strictEqual(result.violations[0].meta.expected_doc_path, 'src/gates/AGENTS.md');
+    assert.strictEqual(result.stats.code_changes_found, 2);
+    assert.strictEqual(result.stats.directories_checked, 2);
+  });
+
+  test('ignores removed files', async () => {
+    const changedFiles = [
+      { filename: 'src/old-module.js', status: 'removed' },
+      { filename: 'src/new-module.js', status: 'added' }
+      // Missing src/AGENTS.md update
+    ];
+    
+    const ctx = createMockContext(changedFiles);
+    const result = await run(ctx, {});
+
+    assert.strictEqual(result.status, 'fail');
+    assert.strictEqual(result.violations.length, 1);
+    assert.strictEqual(result.stats.code_changes_found, 1); // Only new-module.js counted
+  });
+
+  test('ignores AGENTS.md files in code change detection', async () => {
+    const changedFiles = [
+      { filename: 'src/AGENTS.md', status: 'modified' },
+      { filename: 'test/AGENTS.md', status: 'added' }
+    ];
+    
+    const ctx = createMockContext(changedFiles);
+    const result = await run(ctx, {});
+
+    assert.strictEqual(result.status, 'pass');
+    assert.strictEqual(result.violations.length, 0);
+    assert.strictEqual(result.stats.code_changes_found, 0);
+  });
+
+  test('respects custom code patterns configuration', async () => {
+    const changedFiles = [
+      { filename: 'custom/module.py', status: 'added' }
+    ];
+    
+    const ctx = createMockContext(changedFiles);
+    const config = {
+      with: {
+        code_patterns: ['custom/**/*.py'],
+        doc_pattern: 'AGENTS.md'
+      }
+    };
+    
+    const result = await run(ctx, config);
+
+    assert.strictEqual(result.status, 'fail');
+    assert.strictEqual(result.violations.length, 1);
+    assert.strictEqual(result.violations[0].meta.expected_doc_path, 'custom/AGENTS.md');
+  });
+
+  test('respects custom doc pattern configuration', async () => {
+    const changedFiles = [
+      { filename: 'src/module.js', status: 'added' },
+      { filename: 'src/README.md', status: 'modified' }
+    ];
+    
+    const ctx = createMockContext(changedFiles);
+    const config = {
+      with: {
+        doc_pattern: 'README.md'
+      }
+    };
+    
+    const result = await run(ctx, config);
+
+    assert.strictEqual(result.status, 'pass');
+    assert.strictEqual(result.violations.length, 0);
+  });
+
+  test('handles GitHub API errors gracefully', async () => {
+    const ctx = {
+      pr: { number: 123 },
+      repo: () => ({ owner: 'test-org', repo: 'test-repo' }),
+      octokit: {
+        pulls: {
+          listFiles: async () => {
+            throw new Error('API rate limit exceeded');
+          }
+        }
+      }
+    };
+    
+    const result = await run(ctx, {});
+
+    assert.strictEqual(result.status, 'neutral');
+    assert.strictEqual(result.neutral_reason, 'api_error');
+    assert.strictEqual(result.violations.length, 0);
+    assert.strictEqual(result.stats.error, 'API rate limit exceeded');
+  });
+
+  test('avoids duplicate directory checks', async () => {
+    const changedFiles = [
+      { filename: 'src/auth/oauth.js', status: 'added' },
+      { filename: 'src/auth/utils.js', status: 'modified' },
+      { filename: 'src/auth/helpers.js', status: 'modified' }
+      // All in same directory
+    ];
+    
+    const ctx = createMockContext(changedFiles);
+    const result = await run(ctx, {});
+
+    assert.strictEqual(result.status, 'fail');
+    assert.strictEqual(result.violations.length, 1); // Only one violation for the directory
+    assert.strictEqual(result.stats.directories_checked, 1);
+    assert.strictEqual(result.stats.code_changes_found, 3);
+  });
+
+  test('handles root directory changes', async () => {
+    const changedFiles = [
+      { filename: 'index.js', status: 'modified' }
+    ];
+    
+    const ctx = createMockContext(changedFiles);
+    const result = await run(ctx, {});
+
+    assert.strictEqual(result.status, 'fail');
+    assert.strictEqual(result.violations[0].meta.expected_doc_path, 'AGENTS.md');
+    assert.strictEqual(result.violations[0].meta.directory, '.');
+  });
+
+  test('respects CLAUDE.md as custom doc pattern', async () => {
+    const changedFiles = [
+      { filename: 'src/auth/oauth.js', status: 'added' },
+      { filename: 'src/auth/CLAUDE.md', status: 'modified' }
+    ];
+    
+    const ctx = createMockContext(changedFiles);
+    const config = {
+      with: {
+        doc_pattern: 'CLAUDE.md'
+      }
+    };
+    
+    const result = await run(ctx, config);
+
+    assert.strictEqual(result.status, 'pass');
+    assert.strictEqual(result.violations.length, 0);
+    assert.strictEqual(result.stats.code_changes_found, 1);
+    assert.strictEqual(result.stats.directories_checked, 1);
+  });
+
+  test('fails when code changes but CLAUDE.md not updated', async () => {
+    const changedFiles = [
+      { filename: 'src/utils/helper.js', status: 'modified' },
+      { filename: 'src/components/Button.js', status: 'added' }
+    ];
+    
+    const ctx = createMockContext(changedFiles);
+    const config = {
+      with: {
+        doc_pattern: 'CLAUDE.md'
+      }
+    };
+    
+    const result = await run(ctx, config);
+
+    assert.strictEqual(result.status, 'fail');
+    assert.strictEqual(result.violations.length, 2);
+    assert.strictEqual(result.violations[0].meta.expected_doc_path, 'src/utils/CLAUDE.md');
+    assert.strictEqual(result.violations[1].meta.expected_doc_path, 'src/components/CLAUDE.md');
+    assert.strictEqual(result.stats.code_changes_found, 2);
+    assert.strictEqual(result.stats.directories_checked, 2);
+  });
+
+  test('respects README.md as custom doc pattern with specific code patterns', async () => {
+    const changedFiles = [
+      { filename: 'lib/core/engine.ts', status: 'modified' },
+      { filename: 'lib/core/README.md', status: 'modified' },
+      { filename: 'src/unrelated.js', status: 'added' }  // Should be ignored due to code_patterns
+    ];
+    
+    const ctx = createMockContext(changedFiles);
+    const config = {
+      with: {
+        code_patterns: ['lib/**/*.ts'],
+        doc_pattern: 'README.md'
+      }
+    };
+    
+    const result = await run(ctx, config);
+
+    assert.strictEqual(result.status, 'pass');
+    assert.strictEqual(result.violations.length, 0);
+    assert.strictEqual(result.stats.code_changes_found, 1);  // Only the .ts file matches
+    assert.strictEqual(result.stats.directories_checked, 1);
+  });
+});


### PR DESCRIPTION

<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/17e1b595-13fb-4bf1-9dc9-0f3fd765ab59" />


New gate that enforces AGENTS.md files are updated when code changes occur in the same directory.

How it works
When you change code files, the corresponding AGENTS.md must also be updated in the same PR:

✅ This would pass:

Change: src/auth/oauth.js
Also update: src/auth/AGENTS.md
❌ This would fail:

Change: src/auth/oauth.js
Missing: src/auth/AGENTS.md
✅ Multiple directories:

Change: src/gates/registry.js + test/unit/registry.test.js
Also update: src/gates/AGENTS.md + test/unit/AGENTS.md
Configuration
gates:
  - type: agents-md-sync
    id: agents_md_sync
Optional customization:

with:
  code_patterns: ["src/**/*.js", "lib/**/*.ts"]  # Which files trigger the rule
  doc_pattern: "README.md"                       # Alternative to AGENTS.md
Tests
14 unit tests + 8 integration tests passing
Covers default patterns, custom patterns (CLAUDE.md, README.md), error handling
Files
src/gates/cogni/agents-md-sync.js - implementation
test/unit/agents-sync.test.js - unit tests
test/contract/agents-sync-integration.test.js - integration tests
.cogni/repo-spec.yaml - enabled in this repo