### PR TITLE
fix: yaml linting error in rule update

### DIFF
--- a/.cogni/rules/single-check-pr-verdict.yaml
+++ b/.cogni/rules/single-check-pr-verdict.yaml
@@ -2,7 +2,7 @@ id: single-check-pr-verdict
 schema_version: "0.1"
 blocking: true
 
-evaluation-statement: The repo does not deviate from its goal: a single AI-powered Pass/Fail/Neutral verdict on each pull request, derived from potentially multiple rule gates.
+evaluation-statement: "The repo does not deviate from its goal: a single AI-powered Pass/Fail/Neutral verdict on each pull request, derived from potentially multiple rule gates."
 
 # Present, but totally unused for now.
 variables: [pr_title, pr_body, diff_summary]


### PR DESCRIPTION

<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/3555687e-de20-4838-b0b6-0204dd1aaa24" />


New evaluation statement had a colon ":" in it, breaking yaml linting.

Updating this evaluation statement to be fully in quotes. yaml linting passes now.