### PR TITLE
fix: preview deployment OPENAI_API_KEY and YAML formatting

### DIFF
--- a/.do/app.preview.yaml
+++ b/.do/app.preview.yaml
@@ -37,11 +37,11 @@ services:
   - key: OPENAI_API_KEY
     scope: RUN_TIME
     type: SECRET
-    value: ${OPENAI_API_KEY}
+    value: ${PREVIEW_OPENAI_API_KEY}
   - key: PRIVATE_KEY
     scope: RUN_TIME
     type: SECRET
-    value: ${PREVIEW_PRIVATE_KEY} 
+    value: ${PREVIEW_PRIVATE_KEY}
   github:
     branch: main
     repo: Cogni-DAO/cogni-git-review

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -23,4 +23,4 @@ jobs:
          PREVIEW_APP_ID: ${{ vars.PREVIEW_APP_ID }}
          PREVIEW_PRIVATE_KEY: ${{ secrets.PREVIEW_PRIVATE_KEY }}
          PREVIEW_WEBHOOK_SECRET: ${{ secrets.PREVIEW_WEBHOOK_SECRET }}
-         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+         PREVIEW_OPENAI_API_KEY: ${{ secrets.PREVIEW_OPENAI_API_KEY }}


### PR DESCRIPTION

<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/03e83346-43e2-4cb2-81fd-6de0d108623b" />

## Summary
Critical fixes for preview deployment pipeline:

### 🔧 Fixes Applied
- **Environment Variable**: `OPENAI_API_KEY` → `PREVIEW_OPENAI_API_KEY` in both workflow and app spec
- **YAML Formatting**: Removed trailing space causing `yaml: line 46: could not find expected ':'` error

### 🚨 Previous Error
```
Error: failed to create spec: failed to parse app spec: error converting YAML to JSON: yaml: line 46: could not find expected ':'
```

### ✅ Should Now Work
- Preview deployment should succeed with proper YAML parsing
- Environment variables correctly reference preview-specific secrets

## Test Plan
- [x] Fixed YAML syntax (trailing space removed)
- [x] Updated environment variable names to match secrets
- [ ] Deploy to main will test actual preview deployment

Ready to merge and test the preview deployment\!