### PR TITLE
fix: workflow git PAT auth, and clean up workflow and e2e runner

### DIFF
--- a/.do/app.preview.yaml
+++ b/.do/app.preview.yaml
@@ -27,7 +27,7 @@ services:
   - key: OPENAI_API_KEY
     scope: RUN_TIME
     type: SECRET
-    value: ${PREVIEW_OPENAI_API_KEY}
+    value: ${OPENAI_API_KEY}
   - key: PRIVATE_KEY
     scope: RUN_TIME
     type: SECRET

--- a/.github/workflows/e2e-test-preview.yml
+++ b/.github/workflows/e2e-test-preview.yml
@@ -20,7 +20,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' || (github.event_name == 'workflow_dispatch' && github.event.inputs.skip_deploy_check == 'true') }}
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    environment: preview
+    environment: preview-E2E-testing
     env:
       APP_ENV: preview
       TEST_REPO_GITHUB_PAT: ${{ secrets.TEST_REPO_GITHUB_PAT }}
@@ -35,7 +35,7 @@ jobs:
       - run: npm ci --ignore-scripts
       - name: Configure git creds from PAT
         env:
-          GH_TOKEN: ${{ secrets.TEST_REPO_GITHUB_PAT }}   # PAT with repo write
+          GH_TOKEN: ${{ secrets.TEST_REPO_GITHUB_PAT }}
         run: |
           gh auth setup-git
           git config --global user.name  "cogni-bot"

--- a/.github/workflows/e2e-test-preview.yml
+++ b/.github/workflows/e2e-test-preview.yml
@@ -20,7 +20,7 @@ jobs:
       APP_ENV: preview
       TEST_REPO_GITHUB_PAT: ${{ secrets.TEST_REPO_GITHUB_PAT }}
       TEST_REPO: ${{ vars.TEST_REPO }}
-      TIMEOUT_SEC: "480"
+      TIMEOUT_SEC: "120"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/e2e-test-preview.yml
+++ b/.github/workflows/e2e-test-preview.yml
@@ -33,6 +33,13 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci --ignore-scripts
+      - name: Configure git creds from PAT
+        env:
+          GH_TOKEN: ${{ secrets.TEST_REPO_GITHUB_PAT }}   # PAT with repo write
+        run: |
+          gh auth setup-git
+          git config --global user.name  "cogni-bot"
+          git config --global user.email "actions@users.noreply.github.com"
       - run: npm run e2e
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/e2e-test-preview.yml
+++ b/.github/workflows/e2e-test-preview.yml
@@ -7,17 +7,12 @@ on:
     workflows: ["Deploy (Preview)"]
     types: [completed]
   workflow_dispatch:
-    inputs:
-      skip_deploy_check:
-        description: 'Skip deploy success check (for testing)'
-        required: false
-        default: 'false'
 concurrency:
   group: e2e-preview-${{ github.event.workflow_run.head_branch || github.run_id }}
   cancel-in-progress: true
 jobs:
   e2e:
-    if: ${{ github.event.workflow_run.conclusion == 'success' || (github.event_name == 'workflow_dispatch' && github.event.inputs.skip_deploy_check == 'true') }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     timeout-minutes: 15
     runs-on: ubuntu-latest
     environment: preview-E2E-testing

--- a/.github/workflows/e2e-test-preview.yml
+++ b/.github/workflows/e2e-test-preview.yml
@@ -30,8 +30,9 @@ jobs:
       - run: npm ci --ignore-scripts
       - name: Configure git creds from PAT
         env:
-          GH_TOKEN: ${{ secrets.TEST_REPO_GITHUB_PAT }}
+          GH_TOKEN: ${{ secrets.TEST_REPO_GITHUB_PAT }}   # PAT must have write to the test repo
         run: |
+          printf '%s' "$GH_TOKEN" | gh auth login --with-token --hostname github.com
           gh auth setup-git
           git config --global user.name  "cogni-bot"
           git config --global user.email "actions@users.noreply.github.com"

--- a/.github/workflows/e2e-test-preview.yml
+++ b/.github/workflows/e2e-test-preview.yml
@@ -29,10 +29,9 @@ jobs:
           cache: 'npm'
       - run: npm ci --ignore-scripts
       - name: Configure git creds from PAT
-        env:
-          GH_TOKEN: ${{ secrets.TEST_REPO_GITHUB_PAT }}   # PAT must have write to the test repo
         run: |
-          printf '%s' "$GH_TOKEN" | gh auth login --with-token --hostname github.com
+          unset GH_TOKEN                                  
+          printf '%s' "$TEST_REPO_GITHUB_PAT" | gh auth login --with-token --hostname github.com
           gh auth setup-git
           git config --global user.name  "cogni-bot"
           git config --global user.email "actions@users.noreply.github.com"

--- a/AGENTS-RUNBOOK.md
+++ b/AGENTS-RUNBOOK.md
@@ -10,13 +10,9 @@
 
 ## GitHub Configuration
 
-**Environment "preview":**
+**Environment:**
 - Variables: `TEST_REPO`, `APP_ID` 
-- Secrets: `TEST_REPO_GITHUB_PAT`, `PRIVATE_KEY`, `WEBHOOK_SECRET`, `PREVIEW_OPENAI_API_KEY`
-
-**Environment "production":**
-- Variables: `APP_ID`, `CLIENT_ID`
-- Secrets: `PRIVATE_KEY`, `WEBHOOK_SECRET`, `OPENAI_API_KEY`
+- Secrets: `TEST_REPO_GITHUB_PAT`, `PRIVATE_KEY`, `WEBHOOK_SECRET`, `OPENAI_API_KEY`
 
 **Repository:**
 - `DIGITAL_OCEAN_ACCESS_TOKEN`

--- a/docs/E2E.md
+++ b/docs/E2E.md
@@ -28,7 +28,7 @@ gh workflow run "E2E Test (Preview)" --ref main
 | `TEST_REPO_GITHUB_PAT` | ✅ | - | GitHub token for API access |
 | `TEST_REPO` | - | `Cogni-DAO/test-repo` | Target repository |
 | `APP_ENV` | - | `dev` | Environment name (determines check name) |
-| `TIMEOUT_SEC` | - | `480` | Maximum wait time |
+| `TIMEOUT_SEC` | - | `120` | Maximum wait time |
 
 **Check Names by Environment:**
 - `dev` → `"Cogni Git PR Review (dev)"`  

--- a/docs/E2E.md
+++ b/docs/E2E.md
@@ -18,7 +18,7 @@ The GitHub Action `.github/workflows/e2e-test-preview.yml` triggers after succes
 npm run e2e
 
 # Manual GitHub Actions trigger
-gh workflow run "E2E Test (Preview)" --ref main -f skip_deploy_check=true
+gh workflow run "E2E Test (Preview)" --ref main
 ```
 
 ## Environment Variables

--- a/docs/E2E.md
+++ b/docs/E2E.md
@@ -35,6 +35,18 @@ gh workflow run "E2E Test (Preview)" --ref main -f skip_deploy_check=true
 - `preview` → `"Cogni Git PR Review (preview)"`
 - `prod` → `"Cogni Git PR Review"` (locked for branch protection)
 
+## Authentication Setup
+
+**Local Development:**
+- E2E runner uses `TEST_REPO_GITHUB_PAT` for GitHub API operations (`gh` commands)
+- Git push operations work using your existing personal git credentials
+- Both authentication methods must have write access to `TEST_REPO`
+
+**GitHub Actions (CI):**
+- Workflow configures git authentication using `gh auth setup-git` before E2E tests
+- Uses the same `TEST_REPO_GITHUB_PAT` for both API operations and git push
+- Git user configured as `cogni-bot` for commit operations
+
 ## Current Limitations
 
 ⚠️ **This is a MINIMAL test** - current state, not desired state:

--- a/lib/e2e-runner.js
+++ b/lib/e2e-runner.js
@@ -34,8 +34,8 @@ function parseE2EOptionsFromEnv(overrides = {}) {
     ghToken: env('TEST_REPO_GITHUB_PAT'),
     testRepo: env('TEST_REPO', 'Cogni-DAO/test-repo'),
     checkName: PR_REVIEW_NAME,
-    timeoutSec: parseInt(env('TIMEOUT_SEC', '480'), 10),
-    sleepMs: parseInt(env('SLEEP_MS', '5000'), 10),
+    timeoutSec: parseInt(env('TIMEOUT_SEC', '120'), 10),
+    sleepMs: parseInt(env('SLEEP_MS', '10000'), 10),
     ...overrides
   };
 }

--- a/lib/e2e-runner.js
+++ b/lib/e2e-runner.js
@@ -115,16 +115,17 @@ async function runE2ETest(options = {}) {
     console.log(`Waiting for "${checkName}" check (timeout: ${timeoutSec}s)...`);
     const started = Date.now();
     let conclusion = null;
+    let cogni_results = null;
 
     while ((Date.now() - started) / 1000 < timeoutSec) {
       const crJson = sh(`gh api repos/${testRepo}/commits/${headSha}/check-runs -H 'Accept: application/vnd.github+json'`, { env: envWithToken });
       const cr = JSON.parse(crJson);
-      const match = (cr.check_runs || []).find(x => x.name === checkName);
+      cogni_results = (cr.check_runs || []).find(x => x.name === checkName);
       
-      if (match) {
-        console.log(`Check status=${match.status} conclusion=${match.conclusion}`);
-        if (match.status === 'completed') {
-          conclusion = match.conclusion;
+      if (cogni_results) {
+        console.log(`Check status=${cogni_results.status} conclusion=${cogni_results.conclusion}`);
+        if (cogni_results.status === 'completed') {
+          conclusion = cogni_results.conclusion;
           break;
         }
       } else {
@@ -141,7 +142,8 @@ async function runE2ETest(options = {}) {
       check: checkName,
       timeoutSec,
       ts: new Date().toISOString(),
-      result: conclusion || 'timeout'
+      result: conclusion || 'timeout',
+      cogniSummary: cogni_results?.output?.summary || null
     };
 
     // Write summary file for CI artifact


### PR DESCRIPTION
## Summary
- Fix GH_TOKEN guardrail preventing git authentication in E2E workflow
- Resolve "No such device or address" error during git push operations  
- Clean up E2E runner code and add better debugging support

## Key Changes
- Unset GH_TOKEN before `gh auth login` to avoid CLI guardrail blocking credential storage
- Use existing TEST_REPO_GITHUB_PAT environment variable directly in auth step
- Include cogniSummary field in E2E test artifacts for easier failure debugging
- Improve variable naming (match → cogni_results) for code clarity