### PR TITLE
Fix GPT-5 temperature compatibility with centralized LLM client creation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,5 @@ PRIVATE_KEY=
 
 TEST_REPO=<user-id>/test-repo
 TEST_REPO_GITHUB_PAT=
+
+# APP_ENV=preview # Default is dev. Uncomment to run preview-like e2e tests locally. Main behavior change: model selection

--- a/src/ai/AGENTS.md
+++ b/src/ai/AGENTS.md
@@ -25,11 +25,17 @@ const result = await provider.review({
 // Returns: { score: 0.85, observations: [], summary: "Brief assessment", provenance: {} }
 ```
 
-## Model Selection
+## Model Selection & Temperature Policy
 Models selected automatically by environment via `model-selector.js`:
-- **dev**: `gpt-4o-mini` (local development, no APP_ENV)
-- **preview**: `gpt-5-2025-08-07` (APP_ENV=preview)
-- **prod**: `gpt-5-2025-08-07` (APP_ENV=prod)
+- **dev**: `gpt-4o-mini` (local development, no APP_ENV) + `temperature=0`
+- **preview**: `gpt-5-2025-08-07` (APP_ENV=preview) + default temperature
+- **prod**: `gpt-5-2025-08-07` (APP_ENV=prod) + default temperature
+
+**Temperature Policy**: 
+- **Whitelisted models** (`gpt-4o-mini`, `4o-mini`): `temperature=0` for deterministic, repeatable results
+- **All other models**: Use model default (omit parameter) - safer for reasoning models and new releases
+
+LLM client creation centralized in `provider.js makeLLMClient({ model })` with explicit whitelist approach.
 
 Future: Per-rule model overrides from `.cogni/rules/*.yaml` configuration.
 
@@ -42,4 +48,4 @@ Future: Per-rule model overrides from `.cogni/rules/*.yaml` configuration.
 ## Constraints
 - No direct LLM calls outside provider.js
 - Gates decide pass/fail from score vs threshold
-- Temperature=0 for deterministic output
+- LLM client creation only via provider.js makeLLMClient() (enforces temperature policy)

--- a/src/ai/provider.js
+++ b/src/ai/provider.js
@@ -4,8 +4,26 @@
  * Pure shell that forwards I/O to workflows. No extraction or interpretation.
  */
 
+import { ChatOpenAI } from "@langchain/openai";
 import { evaluate } from './workflows/goal-alignment.js';
 import { selectModel, buildContext } from './model-selector.js';
+
+// Models we explicitly want temperature=0 for determinism
+const DETERMINISTIC_MODELS = new Set([
+  "4o-mini",
+  "gpt-4o-mini"
+]);
+
+export function makeLLMClient({ model }) {
+  if (!model) throw new Error("makeLLMClient: 'model' is required");
+
+  const opts = { model };
+  const tempPolicy = DETERMINISTIC_MODELS.has(model) ? "0" : "default(omitted)";
+  if (tempPolicy === "0") opts.temperature = 0; // otherwise omit temperature
+
+  const client = new ChatOpenAI(opts);
+  return { client, meta: { model, tempPolicy } }; // side-effect free
+}
 
 /**
  * Single AI entrypoint router for all gate evaluations
@@ -27,8 +45,12 @@ export async function review(input, { timeoutMs = 60000 } = {}) {
     const modelConfig = selectModel(buildContext());
     console.log('🤖 AI Provider: ModelConfig:', modelConfig);
     
-    // Forward to goal-alignment workflow with model config
-    const result = await evaluate(input, { timeoutMs, modelConfig });
+    // Create LLM client with temperature policy
+    const { client, meta } = makeLLMClient({ model: modelConfig.model });
+    console.log(`🤖 LLM Client: model=${meta.model}, temp=${meta.tempPolicy}`);
+    
+    // Forward to goal-alignment workflow with pre-built client
+    const result = await evaluate(input, { timeoutMs, client });
     
     // Add provenance wrapper with resolved model info
     return {

--- a/test/unit/make-llm-client.test.js
+++ b/test/unit/make-llm-client.test.js
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for makeLLMClient function
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { makeLLMClient } from '../../src/ai/provider.js';
+
+describe('makeLLMClient', () => {
+  it('builds client with temperature=0 for whitelisted model', () => {
+    const { client, meta } = makeLLMClient({ model: 'gpt-4o-mini' });
+    
+    // Verify meta contains expected values
+    assert.strictEqual(meta.model, 'gpt-4o-mini');
+    assert.strictEqual(meta.tempPolicy, '0');
+    
+    // Verify client is created (ChatOpenAI instance)
+    assert(client);
+    assert.strictEqual(typeof client.call, 'function'); // ChatOpenAI has call method
+  });
+
+  it('builds client with temperature=0 for 4o-mini variant', () => {
+    const { client, meta } = makeLLMClient({ model: '4o-mini' });
+    
+    assert.strictEqual(meta.model, '4o-mini');
+    assert.strictEqual(meta.tempPolicy, '0');
+    assert(client);
+  });
+
+  it('omits temperature for non-whitelisted model', () => {
+    const { client, meta } = makeLLMClient({ model: 'gpt-5-2025-08-07' });
+    
+    // Verify meta contains expected values
+    assert.strictEqual(meta.model, 'gpt-5-2025-08-07');
+    assert.strictEqual(meta.tempPolicy, 'default(omitted)');
+    
+    // Verify client is created
+    assert(client);
+    assert.strictEqual(typeof client.call, 'function');
+  });
+
+  it('omits temperature for o1 model', () => {
+    const { client, meta } = makeLLMClient({ model: 'o1-preview' });
+    
+    assert.strictEqual(meta.model, 'o1-preview');
+    assert.strictEqual(meta.tempPolicy, 'default(omitted)');
+    assert(client);
+  });
+
+  it('omits temperature for o3 model', () => {
+    const { client, meta } = makeLLMClient({ model: 'o3-mini' });
+    
+    assert.strictEqual(meta.model, 'o3-mini');
+    assert.strictEqual(meta.tempPolicy, 'default(omitted)');
+    assert(client);
+  });
+
+  it('throws error when model is missing', () => {
+    assert.throws(() => {
+      makeLLMClient({});
+    }, /makeLLMClient: 'model' is required/);
+  });
+
+  it('throws error when model is null', () => {
+    assert.throws(() => {
+      makeLLMClient({ model: null });
+    }, /makeLLMClient: 'model' is required/);
+  });
+
+  it('throws error when model is empty string', () => {
+    assert.throws(() => {
+      makeLLMClient({ model: '' });
+    }, /makeLLMClient: 'model' is required/);
+  });
+
+  it('returns client and meta structure correctly', () => {
+    const result = makeLLMClient({ model: 'gpt-4o-mini' });
+    
+    // Verify structure
+    assert(typeof result === 'object');
+    assert('client' in result);
+    assert('meta' in result);
+    
+    // Verify meta structure
+    assert(typeof result.meta === 'object');
+    assert('model' in result.meta);
+    assert('tempPolicy' in result.meta);
+    
+    // Verify no side effects (no console logging in the factory)
+    assert.strictEqual(typeof result.client, 'object');
+  });
+});


### PR DESCRIPTION
## Problem

The preview environment was experiencing failures with GPT-5 models:
```
AI Provider error: 400 Unsupported value: 'temperature' does not support 0 with this model. Only the default (1) value is supported.
```

## Solution

Centralized LLM client creation with whitelist-based temperature policy:

- **Whitelisted models** (`gpt-4o-mini`, `4o-mini`): `temperature=0` for deterministic results
- **All other models**: Omit temperature parameter (use model defaults)
- **Centralized approach**: All client creation goes through `makeLLMClient({ model })` factory

## Changes

- ✅ Add `makeLLMClient({ model })` factory in `provider.js` with `DETERMINISTIC_MODELS` whitelist
- ✅ Refactor workflows to accept pre-built client instead of creating `ChatOpenAI` directly  
- ✅ Add comprehensive unit tests (9 test cases) for the new factory function
- ✅ Update AGENTS.md documentation for centralized client creation approach
- ✅ Add APP_ENV example to .env.example for local preview testing

## Testing

- ✅ All existing tests pass
- ✅ New unit tests verify whitelist behavior works correctly
- ✅ Temperature logging shows proper policy resolution: `🤖 LLM Client: model=gpt-4o-mini, temp=0`

## Impact

- **Fixes**: GPT-5 "Unsupported value: temperature does not support 0" error in preview/prod
- **Maintains**: Deterministic behavior (`temperature=0`) for development models  
- **Future-proof**: Easy to add new models to whitelist as needed
- **Clean architecture**: Provider handles client creation, workflows handle evaluation

Ready to resolve the preview environment temperature compatibility issue\! 🎯