### PR TITLE
fix(spec): remove disallowed variables property from spec. 

### DIFF
--- a/.cogni/rules/dont-rebuild-oss.yaml
+++ b/.cogni/rules/dont-rebuild-oss.yaml
@@ -5,9 +5,6 @@ workflow_id: single-statement-evaluation
 
 evaluation-statement: Does NOT Re-implement mature OSS tools or libraries.
 
-# Present, but totally unused for now.
-variables: [pr_title, pr_body, diff_summary]
-
 success_criteria:
   neutral_on_missing_metrics: true
   require:

--- a/.cogni/rules/single-check-pr-verdict.yaml
+++ b/.cogni/rules/single-check-pr-verdict.yaml
@@ -5,9 +5,6 @@ workflow_id: single-statement-evaluation
 
 evaluation-statement: "The repo does not deviate from its goal: a single AI-powered Pass/Fail/Neutral verdict on each pull request, derived from potentially multiple rule gates."
 
-# Present, but totally unused for now.
-variables: [pr_title, pr_body, diff_summary]
-
 success_criteria:
   neutral_on_missing_metrics: true
   require:


### PR DESCRIPTION

<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/603fa42f-9947-4839-abd4-b2bcae8c75f4" />


"Variables" property was present in the specs, but was unused. With v0.2 and new schema validation, extra fields are forbidden. removing.