### PR TITLE
fix: E2E test cleanup and workflow improvements

### DIFF
--- a/.github/workflows/e2e-test-preview.yml
+++ b/.github/workflows/e2e-test-preview.yml
@@ -17,10 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: preview-E2E-testing
     env:
-      APP_ENV: preview
       TEST_REPO_GITHUB_PAT: ${{ secrets.TEST_REPO_GITHUB_PAT }}
       TEST_REPO: ${{ vars.TEST_REPO }}
-      TIMEOUT_SEC: "120"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/e2e-test-prod.yml
+++ b/.github/workflows/e2e-test-prod.yml
@@ -17,10 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: production-E2E-testing
     env:
-      APP_ENV: preview
       TEST_REPO_GITHUB_PAT: ${{ secrets.TEST_REPO_GITHUB_PAT }}
       TEST_REPO: ${{ vars.TEST_REPO }}
-      TIMEOUT_SEC: "120"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/lib/e2e-runner.js
+++ b/lib/e2e-runner.js
@@ -1,6 +1,6 @@
 /**
- * Core E2E runner logic for Cogni preview testing.
- * Creates test PR, waits for Cogni check, validates results.
+ * Core E2E runner logic for Cogni E2E testing with a real test-repo.
+ * Uses PAT, creates a test PR, waits for Cogni check, validates results.
  */
 import { execSync } from 'node:child_process';
 import { writeFileSync, mkdirSync, rmSync, mkdtempSync } from 'node:fs';
@@ -100,13 +100,13 @@ async function runE2ETest(options = {}) {
     const stamp = new Date().toISOString();
     sh(`bash -lc "echo '${stamp}' > ${tmp}/.cogni-e2e.txt"`);
     sh(`git -C ${tmp} add .cogni-e2e.txt`);
-    sh(`git -C ${tmp} -c user.name='cogni-bot' -c user.email='actions@users.noreply.github.com' commit -m 'chore(e2e): trigger cogni preview check'`);
+    sh(`git -C ${tmp} -c user.name='cogni-bot' -c user.email='actions@users.noreply.github.com' commit -m 'chore(e2e): trigger cogni PR review check'`);
     sh(`git -C ${tmp} push origin ${branch}`);
 
     // Open PR
     console.log('Creating test PR...');
     // Documented behavior: gh pr create prints PR URL on success
-    const prUrl = sh(`gh pr create -R ${testRepo} --title "E2E: preview ${stamp}" --body "Auto PR by preview E2E" --base main --head ${branch}`, { env: envWithToken });
+    const prUrl = sh(`gh pr create -R ${testRepo} --title "E2E test pr ${stamp}" --body "Auto PR createdby e2e-runner" --base main --head ${branch}`, { env: envWithToken });
     prNumber = prUrl.split('/').pop(); // Extract number from URL
     headSha = sh(`git -C ${tmp} rev-parse HEAD`);
     console.log(`Opened PR #${prNumber}: ${prUrl}`);
@@ -157,7 +157,7 @@ async function runE2ETest(options = {}) {
       // Label and comment for debugging
       try {
         sh(`gh pr edit ${prNumber} -R ${testRepo} --add-label e2e-failed`, { env: envWithToken });
-        sh(`gh pr comment ${prNumber} -R ${testRepo} --body "Preview E2E failed (check: \`${checkName}\`, result: \`${conclusion || 'timeout'}\`). Inspect Cogni logs and rerun."`, { env: envWithToken });
+        sh(`gh pr comment ${prNumber} -R ${testRepo} --body "E2E test failed (check: \`${checkName}\`, result: \`${conclusion || 'timeout'}\`). Inspect Cogni logs and rerun."`, { env: envWithToken });
       } catch (err) {
         console.warn('Failed to label/comment PR:', err.message);
       }

--- a/lib/e2e-runner.js
+++ b/lib/e2e-runner.js
@@ -169,9 +169,8 @@ async function runE2ETest(options = {}) {
       };
     }
 
-    // SUCCESS: Clean up
-    console.log('✅ E2E succeeded — cleaning up test PR/branch.');
-    sh(`gh pr close ${prNumber} -R ${testRepo} --delete-branch`, { env: envWithToken });
+    // SUCCESS
+    console.log('✅ E2E succeeded');
 
     return {
       success: true,
@@ -213,6 +212,17 @@ async function runE2ETest(options = {}) {
       error: error.message || String(error)
     };
   } finally {
+    // Always cleanup test PR/branch
+    if (prNumber) {
+      console.log('🧹 Cleaning up test PR/branch...');
+      try {
+        sh(`gh pr close ${prNumber} -R ${testRepo} --delete-branch`, { env: envWithToken });
+        console.log(`Closed PR #${prNumber} and deleted branch`);
+      } catch (cleanupErr) {
+        console.warn('Failed to cleanup PR/branch:', cleanupErr.message);
+      }
+    }
+
     // Always cleanup temp directory
     try {
       rmSync(tmp, { recursive: true, force: true });

--- a/lib/e2e-runner.js
+++ b/lib/e2e-runner.js
@@ -180,16 +180,6 @@ async function runE2ETest(options = {}) {
 
   } catch (error) {
     console.error('E2E runner error:', error.stderr || error.stack || String(error));
-    
-    // Best effort cleanup on error
-    if (prNumber) {
-      try {
-        sh(`gh pr edit ${prNumber} -R ${testRepo} --add-label e2e-error`, { env: envWithToken });
-        sh(`gh pr comment ${prNumber} -R ${testRepo} --body "E2E runner crashed before completion. Please inspect logs."`, { env: envWithToken });
-      } catch (cleanupErr) {
-        console.warn('Failed to label crashed PR:', cleanupErr.message);
-      }
-    }
 
     const summary = {
       repo: testRepo,


### PR DESCRIPTION
## Summary
- Fixed E2E runner to always clean up test PRs and branches (previously only cleaned up on success)
- Removed hardcoded Preview references from E2E workflows and runner
- Removed failing label operations that referenced non-existent labels

## Changes
- **E2E Runner**: Moved PR cleanup logic to `finally` block ensuring cleanup happens regardless of test outcome
- **Workflows**: Removed unused `APP_ENV` and `TIMEOUT_SEC` environment variables
- **Labels**: Removed `e2e-error` labeling that was causing warnings due to non-existent labels