### PR TITLE
fix: re-add APP_ENV to e2e test github actions

### DIFF
--- a/.github/workflows/e2e-test-preview.yml
+++ b/.github/workflows/e2e-test-preview.yml
@@ -19,6 +19,7 @@ jobs:
     env:
       TEST_REPO_GITHUB_PAT: ${{ secrets.TEST_REPO_GITHUB_PAT }}
       TEST_REPO: ${{ vars.TEST_REPO }}
+      APP_ENV: preview # required for e2e-runner.js computing PR_REVIEW_NAME via src/constants.js
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/e2e-test-prod.yml
+++ b/.github/workflows/e2e-test-prod.yml
@@ -19,6 +19,7 @@ jobs:
     env:
       TEST_REPO_GITHUB_PAT: ${{ secrets.TEST_REPO_GITHUB_PAT }}
       TEST_REPO: ${{ vars.TEST_REPO }}
+      APP_ENV: prod # required for e2e-runner.js computing PR_REVIEW_NAME via src/constants.js
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/ffcbaa03-7553-4ff5-95b8-a7f4aa09ec3e" />

This was removed and accidentally introduced a regression (e2e test searching for (dev) git review instead of preview). Re-adding.