### PR TITLE
Fix: Allow meta property in provider result schema

### DIFF
--- a/src/ai/schemas/AGENTS.md
+++ b/src/ai/schemas/AGENTS.md
@@ -29,7 +29,7 @@ AJV-based JSON schema validation for AI evaluation rules and provider outputs. P
 - **Required fields**: `metrics`, `summary`, `provenance`
 - **Metrics format**: Object with metrics as `{value: number, observations: string[]}` structure
 - **Summary format**: Brief string explanation of the evaluation
-- **Provenance format**: Execution metadata including `runId`, `durationMs`, `workflowId`, `modelConfig`
+- **Provenance format**: Execution metadata including `meta`, `runId`, `durationMs`, `workflowId`, `modelConfig`
 
 ## Validation Flow
 1. **Early validation** in `spec-loader.js loadSingleRule()` on raw YAML data

--- a/src/ai/schemas/provider-result.schema.json
+++ b/src/ai/schemas/provider-result.schema.json
@@ -63,6 +63,11 @@
           "type": "object",
           "description": "Model configuration used",
           "additionalProperties": true
+        },
+        "meta": {
+          "type": "object",
+          "description": "Rich metadata for tracing and debugging",
+          "additionalProperties": true
         }
       }
     }


### PR DESCRIPTION
<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/32651ef5-c248-480f-ae15-1e130afd9df9" />


## Summary
Fix validation error by adding `meta` property to provenance object in provider result schema.

## Changes
- Updated `src/ai/schemas/provider-result.schema.json` to allow `meta` field
- Enables Langfuse tracing metadata (repo, pr_number, commit_sha, etc.)