### PR TITLE
fix: prioritize gate failures over timeout in overall status logic

### DIFF
--- a/src/gates/index.js
+++ b/src/gates/index.js
@@ -64,11 +64,11 @@ export async function runAllGates(context, pr, spec, opts = { deadlineMs: 120000
     const hasFail = allGates.some(r => r.status === 'fail');
     const hasNeutral = allGates.some(r => r.status === 'neutral');
     
-    // Determine overall status
+    // Determine overall status - prioritize failures over partial execution
     const hasNoGates = allGates.length === 0;
     const overall_status = hasNoGates ? 'neutral'
-                         : (isPartial && isAborted) ? 'neutral' 
                          : hasFail ? 'fail' 
+                         : (isPartial && isAborted) ? 'neutral'
                          : (hasNeutral ? 'neutral' : 'pass');
 
     clearTimeout(timeoutId);

--- a/src/pr-comment.js
+++ b/src/pr-comment.js
@@ -12,14 +12,14 @@
  * @param {number} prNumber - PR number
  */
 export async function postPRComment(context, runResult, checkUrl, headSha, prNumber) {
-  const { gates } = runResult;
+  const { gates, overall_status } = runResult;
   const failed = gates.filter(g => g.status === 'fail');
   const neutral = gates.filter(g => g.status === 'neutral');
   const passed = gates.filter(g => g.status === 'pass');
 
-  const verdict = failed.length > 0 ? '❌ FAIL' 
-                : neutral.length > 0 ? '⚠️ WARN' 
-                : '✅ PASS';
+  const verdict = overall_status === 'fail' ? '❌ FAIL' 
+                : overall_status === 'pass' ? '✅ PASS' 
+                : '⚠️ WARN';
 
   let body = `## Cogni Review — ${verdict}\n\n`;
   body += `**Gates:** ✅ ${passed.length} | ❌ ${failed.length} | ⚠️ ${neutral.length}\n\n`;

--- a/src/summary-adapter.js
+++ b/src/summary-adapter.js
@@ -46,13 +46,13 @@ function formatGateResults(runResult) {
     neutral: groups.neutral.length
   };
   
-  // Generate summary line
+  // Generate summary line based on overall status
   let summary;
   if (gates.length === 0) {
     summary = 'No gates configured';
-  } else if (counts.fail > 0) {
+  } else if (runResult.overall_status === 'fail') {
     summary = `Gate failures: ${counts.fail}`;
-  } else if (counts.neutral > 0) {
+  } else if (runResult.overall_status === 'neutral') {
     summary = `Gates neutral: ${counts.neutral}`;
   } else {
     summary = 'All gates passed';


### PR DESCRIPTION
## Summary
- Fixed critical bug where failed gates showed as NEUTRAL when execution timed out
- Ensured PR comments and GitHub check results show consistent verdicts
- Prioritized gate failures over partial execution timeouts

## Root Cause
The gate decision logic incorrectly prioritized `(isPartial && isAborted)` over `hasFail`, causing failed gates to be masked as NEUTRAL when execution timed out.

## Changes
- **src/gates/index.js**: Reordered status logic to prioritize failures
- **src/pr-comment.js**: Use `overall_status` instead of recalculating from gate counts  
- **src/summary-adapter.js**: Use `overall_status` consistently for summary titles

## Evidence
- GitHub Actions run 51685740102: "✅ 4 passed | ❌ 3 failed" → showed NEUTRAL (now FAIL)
- GitHub Actions run 51686648707: "✅ 5 passed | ❌ 2 failed" → showed NEUTRAL (now FAIL)

## Test Plan
- [x] All existing tests pass
- [x] Timeout scenarios with failed gates now return FAIL status
- [x] PR comment and check result verdicts are now consistent

## Related
- Addresses Cogni MCP bug 627ee1ae (P0 production issue)
- Notes related orchestrator bug 2b6309d7 for future fix