### PR TITLE
feat: add fail_on_error flag to control GitHub check blocking behavior

### DIFF
--- a/.cogni/repo-spec.yaml
+++ b/.cogni/repo-spec.yaml
@@ -11,6 +11,11 @@ required_status_contexts:
   - Security
   - Cogni Git PR Review
 
+# Control GitHub check conclusion behavior for gate errors/timeouts
+# false (default): errors/timeouts result in 'neutral' conclusion (non-blocking)
+# true: errors/timeouts result in 'failure' conclusion (blocks merge)
+fail_on_error: false
+
 # Gates run in the order they appear below.
 gates:
   # Governance policy - check required workflows exist and match contexts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,10 @@ context.payload.pull_request = pr;
 ## Gate Configuration
 Quality gates are configured in each repository's `.cogni/repo-spec.yaml`:
 ```yaml
+# GitHub Check Behavior Control
+fail_on_error: false     # Default: cogni Github response is Neutral when the app/gate hits errors 
+                         # true: neutral errors become failure (blocking)
+
 gates:
   # Built-in gates with explicit type + id
   - type: review-limits
@@ -127,6 +131,7 @@ gates:
 - **Enhanced diagnostics**: Detailed execution summaries with per-gate timeout attribution, pass/fail/neutral counts, and conclusion reasoning
 - **Robust error handling**: Gate crashes become neutral results with preserved diagnostic information
 - **Universal gate logging**: Every gate logs start and completion with status, duration, and diagnostic context
+- **Configurable neutral handling**: `fail_on_error` flag controls whether gate errors/timeouts block merges (failure) or allow them (neutral)
 
 ## Development
 

--- a/cogni-rails-templates-v0.1/.cogni/repo-spec-template.yaml
+++ b/cogni-rails-templates-v0.1/.cogni/repo-spec-template.yaml
@@ -14,6 +14,11 @@ required_status_contexts:
   - Security
   - Cogni Git PR Review
 
+# Control GitHub check conclusion behavior for gate errors/timeouts
+# false (default): errors/timeouts result in 'neutral' conclusion (non-blocking)
+# true: errors/timeouts result in 'failure' conclusion (blocks merge)
+fail_on_error: false
+
 # Gates run in the order they appear below.
 gates:
   # Built-in gates (run directly in bot process)

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ export default (app) => {
   }
 
   async function createCompletedCheck(context, runResult, headSha, startTime, log) {
-    const conclusion = mapStatusToConclusion(runResult.overall_status);
+    const conclusion = mapStatusToConclusion(runResult.overall_status, context.spec.fail_on_error);
     const { summary, text } = renderCheckSummary(runResult);
 
     const checkResult = await context.octokit.checks.create(context.repo({
@@ -72,12 +72,14 @@ export default (app) => {
   /**
    * Map tri-state status to GitHub check conclusion
    */
-  function mapStatusToConclusion(status) {
+  function mapStatusToConclusion(status, errorOnNeutral) {
+    const default_response = errorOnNeutral ? 'failure' : 'neutral';
+
     switch (status) {
       case 'pass': return 'success';
       case 'fail': return 'failure';
-      case 'neutral': return 'neutral';
-      default: return 'neutral';
+      case 'neutral': return default_response;
+      default: return default_response;
     }
   }
 

--- a/test/contract/AGENTS.md
+++ b/test/contract/AGENTS.md
@@ -131,6 +131,7 @@ Contract tests run the entire suite in ~5 seconds vs 30+ with HTTP mocking.
 - `template-customization.test.js` - Template replacement validation (repo-spec + CODEOWNERS customization)
 - `agents-sync-integration.test.js` - AGENTS.md synchronization gate integration tests
 - `model-provenance-display.test.js` - Model provenance display in GitHub Check summaries (uses structured AI gate mocks)
+- `error-on-neutral.test.js` - **NEW**: Tests for `fail_on_error` flag behavior - validates that neutral gate results convert to failure/neutral conclusions based on flag setting
 
 ## Logger Requirements
 

--- a/test/contract/error-on-neutral.test.js
+++ b/test/contract/error-on-neutral.test.js
@@ -1,0 +1,47 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+import { testEventHandler } from '../helpers/handler-harness.js';
+import payload from '../fixtures/pull_request.opened.complete.json' with { type: 'json' };
+
+describe('Error On Neutral Flag Contract Tests', () => {
+
+  test('fail_on_error: false (default) - neutral status creates neutral conclusion', async () => {
+    await testEventHandler({
+      event: 'pull_request.opened',
+      payload,
+      spec: 'errorOnNeutralDefault', // Use proper fixture
+      expectCheck: (params) => {
+        // Verify that neutral status becomes neutral conclusion (default behavior)
+        assert.strictEqual(params.conclusion, 'neutral');
+        assert.strictEqual(params.name, 'Cogni Git PR Review (dev)');
+      }
+    });
+  });
+
+  test('fail_on_error: true - neutral status creates failure conclusion', async () => {
+    await testEventHandler({
+      event: 'pull_request.opened',
+      payload,
+      spec: 'errorOnNeutralTrue', // Use proper fixture
+      expectCheck: (params) => {
+        // Verify that neutral status becomes failure conclusion when fail_on_error: true
+        assert.strictEqual(params.conclusion, 'failure');
+        assert.strictEqual(params.name, 'Cogni Git PR Review (dev)');
+      }
+    });
+  });
+
+  test('fail_on_error: true - pass status still creates success conclusion', async () => {
+    // Verify that pass status is unaffected by the flag - use fixture with passing gates
+    await testEventHandler({
+      event: 'pull_request.opened',
+      payload,
+      spec: 'minimalErrorOnNeutral', // Uses our new fixture with fail_on_error: true
+      expectCheck: (params) => {
+        // Verify that pass status creates success conclusion regardless of fail_on_error flag
+        assert.strictEqual(params.conclusion, 'success');
+        assert.strictEqual(params.name, 'Cogni Git PR Review (dev)');
+      }
+    });
+  });
+});

--- a/test/fixtures/AGENTS.md
+++ b/test/fixtures/AGENTS.md
@@ -22,6 +22,8 @@ Reusable test data that eliminates duplication across test suites.
 - `multipleAIRules` - Multiple AI rule instances
 - `agentsSync`, `agentsSyncWithCustomConfig`, `agentsSyncWithOtherGates` - AGENTS.md sync testing
 - `governance`, `governanceNoContexts`, `governanceUnknownContext` - Governance policy testing MVP
+- `minimalErrorOnNeutral` - Minimal spec with `fail_on_error: true` flag for blocking error behavior testing
+- `errorOnNeutralDefault`, `errorOnNeutralTrue` - Specs with unknown gates for testing neutral→failure conversion behavior
 
 ## Principles
 - Use fixtures instead of inline test data

--- a/test/fixtures/repo-specs.js
+++ b/test/fixtures/repo-specs.js
@@ -19,6 +19,25 @@ gates:
       max_changed_files: 100
       max_total_diff_kb: 500`,
 
+  // Minimal spec with fail_on_error: true
+  minimalErrorOnNeutral: `schema_version: '0.2.1'
+
+intent:
+  name: minimal-project
+  goals:
+    - Basic project functionality
+  non_goals:
+    - Complex features
+
+fail_on_error: true
+
+gates:
+  - type: review-limits
+    id: review_limits
+    with:
+      max_changed_files: 100
+      max_total_diff_kb: 500`,
+
   // Valid full spec with all gates enabled
   full: `schema_version: '0.2.1'
 
@@ -432,7 +451,36 @@ required_status_contexts:
 
 gates:
   - type: governance-policy
-    id: governance_policy`
+    id: governance_policy`,
+
+  // Error on neutral testing fixtures
+  errorOnNeutralDefault: `schema_version: '0.2.1'
+
+intent:
+  name: test-neutral-default
+  goals:
+    - Test neutral behavior with default flag
+  non_goals:
+    - Blocking behavior
+
+gates:
+  - type: unknown-gate-type
+    id: unknown_gate`,
+
+  errorOnNeutralTrue: `schema_version: '0.2.1'
+
+intent:
+  name: test-neutral-blocking
+  goals:
+    - Test neutral behavior with fail_on_error true
+  non_goals:
+    - Non-blocking behavior
+
+fail_on_error: true
+
+gates:
+  - type: unknown-gate-type
+    id: unknown_gate`
 };
 
 // Helper for accessing specs by key  

--- a/test/unit/AGENTS.md
+++ b/test/unit/AGENTS.md
@@ -19,7 +19,7 @@ Tests for individual functions and components in isolation, without external dep
 - `agents-sync.test.js` - AGENTS.md synchronization gate tests
 - `ai-provider.test.js` - AI provider contract validation with observation handling and logger parameters
 - `ai-rule-input-validation.test.js` - AI rule input assembly and validation tests
-- `check-contract.min.test.js` - Enforce github Check name follows environment-aware pattern (prod locked, others get suffix)
+- `check-contract.min.test.js` - Enforce github Check name follows environment-aware pattern (prod locked, others get suffix). **Updated**: Added tests for `fail_on_error` flag behavior in `mapStatusToConclusion` function
 - `config-extraction-debug.test.js` - Configuration extraction debugging
 - `eval-criteria.test.js` - Success criteria evaluation logic tests for multi-metric evaluation
 - `forbidden-scopes-stub.test.js` - Forbidden scopes gate stub tests

--- a/test/unit/check-contract.min.test.js
+++ b/test/unit/check-contract.min.test.js
@@ -62,8 +62,22 @@ describe('Check Contract — Minimal Drift Guard', () => {
       "Missing required mapping: fail → failure"
     );
     assert.ok(
-      /case\s*['"]neutral['"]\s*:\s*return\s*['"]neutral['"]/.test(indexSource),
-      "Missing required mapping: neutral → neutral"
+      /case\s*['"]neutral['"]\s*:\s*return\s*default_response/.test(indexSource),
+      "Missing required mapping: neutral → default_response"
+    );
+  });
+
+  test('fail_on_error flag controls neutral conclusion behavior', () => {
+    // Verify the function takes errorOnNeutral parameter
+    assert.ok(
+      /function\s+mapStatusToConclusion\s*\(\s*status\s*,\s*errorOnNeutral\s*\)/.test(indexSource),
+      "mapStatusToConclusion must accept errorOnNeutral parameter"
+    );
+    
+    // Verify default_response logic uses the flag
+    assert.ok(
+      /const\s+default_response\s*=\s*errorOnNeutral\s*\?\s*['"]failure['"]\s*:\s*['"]neutral['"]/.test(indexSource),
+      "default_response must use errorOnNeutral flag to choose failure vs neutral"
     );
   });
 


### PR DESCRIPTION
## Summary
- Adds configurable `fail_on_error` flag to control GitHub check conclusion behavior
- When `fail_on_error: true`, gate errors/timeouts result in blocking failure conclusions  
- When `fail_on_error: false` (default), gate errors/timeouts result in non-blocking neutral conclusions
- Addresses GitHub's neutral=non-blocking behavior by allowing repos to opt into failure conclusions

## Implementation Details
- Modified `mapStatusToConclusion()` to accept `fail_on_error` parameter from repo spec
- Added comprehensive test fixtures and contract tests for both flag states
- Updated all relevant AGENTS.md documentation

## Test Plan
- [x] Unit tests validate `mapStatusToConclusion` parameter handling
- [x] Contract tests verify neutral→failure/neutral conversion based on flag
- [x] All existing tests continue to pass (189 tests, 0 failures)
- [x] Test fixtures follow DRY principles using proper `SPEC_FIXTURES`

## Breaking Changes
None - feature is opt-in with safe default behavior.