### PR TITLE
feat: implement Grafana Cloud Loki centralized logging

### DIFF
--- a/.do/app.preview.yaml
+++ b/.do/app.preview.yaml
@@ -51,6 +51,17 @@ services:
     scope: RUN_TIME
     type: SECRET
     value: ${LANGFUSE_BASE_URL}
+  - key: LOKI_URL
+    scope: RUN_TIME
+    value: ${LOKI_URL}
+  - key: LOKI_USER
+    scope: RUN_TIME
+    type: SECRET
+    value: ${LOKI_USER}
+  - key: LOKI_TOKEN
+    scope: RUN_TIME
+    type: SECRET
+    value: ${LOKI_TOKEN}
   github:
     branch: main
     repo: Cogni-DAO/cogni-git-review

--- a/.do/app.prod.yaml
+++ b/.do/app.prod.yaml
@@ -54,6 +54,17 @@ services:
     scope: RUN_TIME
     type: SECRET
     value: ${LANGFUSE_BASE_URL}
+  - key: LOKI_URL
+    scope: RUN_TIME
+    value: ${LOKI_URL}
+  - key: LOKI_USER
+    scope: RUN_TIME
+    type: SECRET
+    value: ${LOKI_USER}
+  - key: LOKI_TOKEN
+    scope: RUN_TIME
+    type: SECRET
+    value: ${LOKI_TOKEN}
   github:
     branch: main
     deploy_on_push: false

--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@ LANGFUSE_PUBLIC_KEY= "pk-lf-..."
 LANGFUSE_BASE_URL= "https://cloud.langfuse.com" # 🇪🇺 EU region
 # LANGFUSE_BASE_URL = "https://us.cloud.langfuse.com" # 🇺🇸 US region
 
+# Optional: Grafana Cloud Loki log forwarding
+# LOKI_URL=https://logs-prod-021.grafana.net
+# LOKI_USER=1353279
+# LOKI_TOKEN=glc_eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9...
 
 TEST_REPO=<user-id>/test-repo
 TEST_REPO_GITHUB_PAT=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ The bot reads `.cogni/repo-spec.yaml` from repositories and evaluates configured
 - **Dynamic Gate Discovery**: Registry-based discovery with timeout handling
 - **Events**: `pull_request.opened/synchronize/reopened`, `check_suite.rerequested`
 - **AI Provider Architecture**: Generic workflow router with no domain-specific logic
+- **Centralized Logging**: Grafana Cloud Loki integration for production log aggregation
 
 ### Key Resources
 - [Probot Framework Docs](https://probot.github.io/docs/)
@@ -70,7 +71,7 @@ context.payload.pull_request = pr;
 ├── lib/e2e-runner.js          # E2E testing implementation
 ├── src/
 │   ├── spec-loader.js         # Repository specification loading
-    ├── logging/               # Repo-wide logging setup
+    ├── logging/               # Repo-wide logging setup with Loki integration (→ AGENTS.md)
 │   └── gates/                 # Gate evaluation system (→ AGENTS.md)
 │       ├── cogni/             # Built-in quality gates (→ AGENTS.md) 
 ├── test/                      # Test suites and fixtures (→ AGENTS.md)
@@ -157,7 +158,9 @@ npm run lint  # ESLint for JavaScript code
 npm run lint:workflows  # actionlint for GitHub Actions workflows
 ```
 
-**Optional Observability**: Set `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_BASE_URL` for AI tracing.
+**Optional Observability**: 
+- **AI Tracing**: Set `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_BASE_URL` for AI tracing
+- **Centralized Logging**: Set `LOKI_URL`, `LOKI_USER`, and `LOKI_TOKEN` for Grafana Cloud Loki integration
 
 
 ## Integration Strategy

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "langfuse-langchain": "^3.38.5",
         "micromatch": "^4.0.8",
         "pino": "^9.12.0",
+        "pino-loki": "^2.6.0",
         "probot": "^13.0.1",
         "zod": "^3.25.76"
       },
@@ -4459,6 +4460,22 @@
         "pino": "^9.0.0",
         "pino-std-serializers": "^7.0.0",
         "process-warning": "^5.0.0"
+      }
+    },
+    "node_modules/pino-loki": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/pino-loki/-/pino-loki-2.6.0.tgz",
+      "integrity": "sha512-Qy+NeIdb0YmZe/M5mgnO5aGaAyVaeqgwn45T6VajhRXZlZVfGe1YNYhFa9UZyCeNFAPGaUkD2e9yPGjx+2BBYA==",
+      "license": "MIT",
+      "dependencies": {
+        "pino-abstract-transport": "^2.0.0",
+        "pump": "^3.0.2"
+      },
+      "bin": {
+        "pino-loki": "dist/cli.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Julien-R44"
       }
     },
     "node_modules/pino-pretty": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "langfuse-langchain": "^3.38.5",
     "micromatch": "^4.0.8",
     "pino": "^9.12.0",
+    "pino-loki": "^2.6.0",
     "probot": "^13.0.1",
     "zod": "^3.25.76"
   },

--- a/src/logging/AGENTS.md
+++ b/src/logging/AGENTS.md
@@ -4,8 +4,8 @@
 
 ## Setup
 
-- `src/logging/logger.js` - Pino factory with redaction and environment handling
-- `src/logging/index.js` - Exports `appLogger` and `getRequestLogger(context, bindings)`
+- `src/logging/logger.js` - Pino factory with redaction, environment handling, and Loki transport configuration
+- `src/logging/index.js` - Exports `appLogger` and `getRequestLogger(context, bindings)` which always uses appLogger
 
 ## Core Pattern
 
@@ -72,9 +72,26 @@ log.error({ err: error, pr: prNumber }, 'gate failed');
 
 ## Environment Behavior
 
-- **dev**: Pretty printed logs via pino-pretty
-- **prod/preview**: JSON to stdout for log aggregation  
+- **dev**: Pretty printed logs via pino-pretty transport
+- **prod/preview**: 
+  - With Loki configuration: Logs sent to Grafana Cloud Loki for centralized aggregation
+  - Without Loki configuration: JSON to stdout fallback
 - **test**: Disabled (`enabled: false`) - use mock loggers in tests
+
+### Loki Integration
+
+Production and preview environments support centralized logging to Grafana Cloud Loki when configured:
+
+**Required Environment Variables:**
+- `LOKI_URL`: The Loki endpoint URL
+- `LOKI_USER`: Authentication username
+- `LOKI_TOKEN`: Authentication token
+
+**Loki Transport Features:**
+- Batching enabled for efficient log transmission
+- 5-second timeout for resilience
+- Automatic labels: `app` (PR_REVIEW_NAME) and `env` (environment name)
+- Falls back to JSON stdout if any Loki variable is missing
 
 ## Architecture Rules
 
@@ -94,15 +111,17 @@ log.error({ err: error, pr: prNumber }, 'gate failed');
 
 ### Why we pass our own logger even though `context.log` exists from Probot:
 
+- **Centralized Logging**: `getRequestLogger()` always returns appLogger (with Loki transport) instead of Probot's context.log, ensuring all logs flow through our configured transports.
+
 - **Decoupling**: Modules shouldn't know Probot. They depend on a small logging interface, not a large framework object.
 
 - **Testability**: Unit tests inject a mock logger. No fake Probot context required.
 
 - **Portability**: Same modules run in CLIs, queues, or workers that have no Probot.
 
-- **Policy in one place**: Redaction, pretty vs JSON, fields, and levels live in our factory, not scattered.
+- **Policy in one place**: Redaction, transport selection (pino-pretty/Loki/JSON), fields, and levels live in our factory, not scattered.
 
-- **Single source in code**: Downstream code uses only logger, never context.log. Fewer surprises.
+- **Single source in code**: Downstream code uses only logger, never context.log. All application logs go through the same pipeline.
 
 ## Probot vs App Logging
 
@@ -116,12 +135,10 @@ log.error({ err: error, pr: prNumber }, 'gate failed');
 
 **Development logging:**
 ```bash
-npm start  # Raw JSON logs (production-ready for log aggregation)
-
-# Manual pretty formatting when needed:
-npm start | npx pino-pretty --singleLine --ignore pid,hostname
+npm start  # Pretty-printed logs via pino-pretty transport (automatic in dev environment)
 ```
 
 **Dashboard views:**
 - **App Events**: filter `module:*`
 - **Platform Logs**: exclude `module:*` or filter Probot categories
+- **Grafana Cloud**: Query Loki datasource with labels `{app="cogni-pr-review", env="prod|preview"}` in production environments

--- a/src/logging/index.js
+++ b/src/logging/index.js
@@ -11,10 +11,8 @@ export const noop = noopLogger;
  * @returns {Object} Pino logger instance
  */
 export function getRequestLogger(context, bindings = {}) {
-  // Prefer Probot's context.log (already a Pino child) over appLogger
-  const base = context?.log?.child ? context.log : appLogger;
-  
-  return base.child({ 
+  // Always use appLogger (with Loki transport) instead of Probot's context.log
+  return appLogger.child({ 
     id: context?.id || 'unknown',
     repo: context?.payload?.repository?.full_name,
     ...bindings 

--- a/src/logging/logger.js
+++ b/src/logging/logger.js
@@ -1,5 +1,7 @@
 // src/logging/logger.js
 import pino from "pino";
+import {PR_REVIEW_NAME} from "../constants.js";
+import {env} from "../env.js";
 
 const redactPaths = [
   // auth + secrets
@@ -10,25 +12,61 @@ const redactPaths = [
 ];
 
 export function makeLogger(bindings = {}) {
-  const isTest = process.env.NODE_ENV === "test";
+  const isTest = env.isTest;
+  
+  const LOKI_URL   = process.env.LOKI_URL;
+  const LOKI_USER  = process.env.LOKI_USER;
+  const LOKI_TOKEN = process.env.LOKI_TOKEN;
+  const lokiEnabled = !!(LOKI_URL && LOKI_USER && LOKI_TOKEN);
 
-  return pino({
+  let transport;
+  if (env.isDev) {
+    transport = { target: "pino-pretty", options: { singleLine: true } };
+  } else if (lokiEnabled) {
+    transport = {
+      target: "pino-loki",
+      options: {
+        host: LOKI_URL,
+        basicAuth: {
+          username: LOKI_USER,
+          password: LOKI_TOKEN,
+        },
+        batching: true,
+        labels: { app: PR_REVIEW_NAME, env: env.app },
+        timeout: 5000,
+      },
+    };
+  }
+
+  const logger = pino({
     level: process.env.LOG_LEVEL || "info",
     enabled: !isTest,                     // tests stay silent
     base: {
-      app: process.env.APP_NAME || "cogni-git-review",
-      env: process.env.NODE_ENV || "dev",
+      app: PR_REVIEW_NAME,
+      env: env.app,
       version: process.env.APP_VERSION,   // inject at build
       commit: process.env.GIT_SHA,        // inject at build
       ...bindings,
     },
+
     messageKey: "msg",
     timestamp: pino.stdTimeFunctions.epochTime,  // easy to index
     redact: { paths: redactPaths, censor: "[REDACTED]" }, // switch to remove: true for cookies later
-    transport: process.env.NODE_ENV === "development"
-      ? { target: "pino-pretty", options: { singleLine: true } }
-      : undefined,                        // prod: raw JSON to stdout
+    transport,
   });
+
+  // Log transport configuration on startup (only for non-test environments)
+  if (!isTest) {
+    if (env.isDev) {
+      logger.info("Logger configured with pino-pretty transport (development mode)");
+    } else if (lokiEnabled) {
+      logger.info({ lokiUrl: LOKI_URL, lokiUser: LOKI_USER }, "Logger configured with Loki transport");
+    } else {
+      logger.info("Logger configured with JSON stdout transport (production mode)");
+    }
+  }
+
+  return logger;
 }
 
 export const noopLogger = {


### PR DESCRIPTION

<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/0027622b-af71-4f63-95b4-88ec7550a91b" />


## Summary

Implements centralized logging to Grafana Cloud Loki for production environments. Application logs now route through Loki when configured, with fallback to stdout for backward compatibility.

## Key Changes

- **Add pino-loki transport** for Grafana Cloud Loki integration
- **Environment-based transport selection**:
  - Development: pino-pretty for readable console output
  - Production/Preview: Loki transport when env vars provided
  - Fallback: JSON stdout when Loki vars missing
- **Fix application log routing**: `getRequestLogger()` now always uses appLogger (with Loki transport) instead of Probot's context.log
- **Add deployment configuration**: LOKI_URL/LOKI_USER/LOKI_TOKEN env vars for preview/prod
- **Update documentation**: Document Loki integration in logging AGENTS.md

## Environment Variables

- `LOKI_URL`: Grafana Cloud Loki endpoint  
- `LOKI_USER`: Authentication username
- `LOKI_TOKEN`: Grafana Cloud API token

## Benefits

- **Centralized production logging** with Grafana Cloud integration
- **Agent access** to operational logs for debugging
- **Cost-efficient** alternative to DigitalOcean OpenSearch  
- **Maintains backward compatibility** with existing deployments
- **Zero-downtime deployment** - graceful fallback when Loki unavailable

## Note

Probot framework logs still route to stdout (P1 improvement tracked separately in bug `723cc907-9a51-4d5b-982e-fc505e2e513e`). This PR addresses application business logic logging only.