### PR TITLE
fix: set NODE_ENV=development for lint in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,8 @@ jobs:
           # Otherwise: cache: 'npm'
       - run: npm ci
       - run: npm run lint --if-present
+        env:
+          NODE_ENV: development
       
       - name: Install and Run actionlint
         run: |


### PR DESCRIPTION

<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/e7b3d93e-a4b4-4d6a-8a1d-8bea77bf8fe8" />

## Problem
CI lint step fails when ESLint config imports modules that have environment validation side effects.

## Solution
Set `NODE_ENV=development` for the lint step to ensure environment validation uses development defaults instead of failing on missing production variables.

## Context
This is a precursor fix for #106 which introduces centralized environment validation. The lint step needs to run without requiring production environment variables.

## Changes
- Add `NODE_ENV=development` to the lint step in CI workflow
- Ensures ESLint can import config files that depend on environment validation

Fixes the CI failure blocking #106.