### PR TITLE
fix: set consistent NODE_ENV=test for CI operations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       - run: npm ci
       - run: npm run lint --if-present
         env:
-          NODE_ENV: development
+          NODE_ENV: test
       
       - name: Install and Run actionlint
         run: |
@@ -28,3 +28,5 @@ jobs:
           sudo mv ./actionlint /usr/local/bin/
           npm run lint:workflows
       - run: npm test
+        env:
+          NODE_ENV: test


### PR DESCRIPTION

<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/60baa794-6d88-4930-b761-e9939bb2118a" />

## Summary
- Set NODE_ENV=test for both npm run lint and npm test commands in CI
- More semantically correct (CI is a testing environment)  
- Ensures consistent behavior across all CI operations
- Both commands now use same conditional environment validation rules

## Context
This fixes CI failures where lint and test operations had inconsistent NODE_ENV settings. With the recent environment centralization work, both operations need the same NODE_ENV to benefit from conditional validation that makes required fields optional in test environments.

## Test plan
- [x] Local testing confirms both `NODE_ENV=test npm run lint` and `NODE_ENV=test npm test` pass
- [x] CI should now pass consistently for both operations