### PR TITLE
fix: add NODE_ENV=test for E2E workflows

### DIFF
--- a/.github/workflows/e2e-test-preview.yml
+++ b/.github/workflows/e2e-test-preview.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: preview-E2E-testing
     env:
+      NODE_ENV: test # E2E test runner environment (separate from preview deployment being validated)
       TEST_REPO_GITHUB_PAT: ${{ secrets.TEST_REPO_GITHUB_PAT }}
       TEST_REPO: ${{ vars.TEST_REPO }}
       APP_ENV: preview # required for e2e-runner.js computing PR_REVIEW_NAME via src/constants.js

--- a/.github/workflows/e2e-test-prod.yml
+++ b/.github/workflows/e2e-test-prod.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production-E2E-testing
     env:
+      NODE_ENV: test # E2E test runner environment (separate from production deployment being validated)
       TEST_REPO_GITHUB_PAT: ${{ secrets.TEST_REPO_GITHUB_PAT }}
       TEST_REPO: ${{ vars.TEST_REPO }}
       APP_ENV: prod # required for e2e-runner.js computing PR_REVIEW_NAME via src/constants.js


### PR DESCRIPTION

<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/74a8f16b-5ebd-4251-bb74-e23a9225ebaf" />

## Summary
- Add NODE_ENV=test to E2E test runner workflows (preview and production)
- Fixes E2E workflow failures due to environment validation requiring production secrets
- E2E test runner environment is separate from the deployments being validated

## Related
- Follows PR #106 (environment centralization)
- Builds on PR #107 and #109 (CI NODE_ENV fixes)

## Test plan
- [x] Confirmed NODE_ENV=test works locally for E2E runner