### PR TITLE
Fix: Pass model config provenance to summary adapter

### DIFF
--- a/src/gates/cogni/AGENTS.md
+++ b/src/gates/cogni/AGENTS.md
@@ -99,5 +99,6 @@ The `ai-rule` gate supports dynamic AI evaluation with schema v0.3:
 
 **Standard Result Structure**:
 - **AI gates** (rules.js): Return per-metric observations within providerResult.metrics structure
+  - **Provenance tracking**: AI gate decisions now include `provenance: providerResult.provenance` to track which AI provider and model was used for evaluation (enables model/provider display in GitHub check summaries)
 - **Stub gates** (goal-declaration-stub.js, forbidden-scopes-stub.js): Return violations with `observation` messages
 - All gates return normalized `{status, violations[], stats, duration_ms}` format

--- a/src/gates/cogni/rules.js
+++ b/src/gates/cogni/rules.js
@@ -158,6 +158,7 @@ function makeGateDecision(providerResult, rule, startTime) {
     res,
     providerResult,
     rule,
+    provenance: providerResult.provenance,
     duration_ms: Date.now() - startTime
   };
 }


### PR DESCRIPTION

<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/819e1077-fc78-489b-85f9-863453824b19" />

## Summary
Fixes missing model/provider display in AI gate results by passing through provenance data.

## Changes
- Added `provenance: providerResult.provenance` to gate decision output in `src/gates/cogni/rules.js:161`
- This enables the summary adapter to display which AI provider and model was used for each gate evaluation

## Test plan
- [ ] Verify gate results now show provider/model information in GitHub check output
- [ ] Test with different AI providers to confirm provenance data is correctly passed through