### PR TITLE
Update root AGENTS.md to reference specialized subagents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,15 @@ The bot reads `.cogni/repo-spec.yaml` from repositories and evaluates configured
 - **AI Provider Architecture**: Generic workflow router with no domain-specific logic
 - **Centralized Logging**: Grafana Cloud Loki integration for production log aggregation
 
+## Agent Team
+You are on a team full of specialized agents. If you have access use agents, do it!
+- code-reviewer.md
+- docs-synchronizer.md
+- senior-developer.md
+- system-architect.md
+- test-strategist.md
+- validation-engineer.md
+
 ### Key Resources
 - [Probot Framework Docs](https://probot.github.io/docs/)
 - [GitHub Checks API](https://docs.github.com/en/rest/checks)


### PR DESCRIPTION
## Summary
Updates root documentation to reference and encourage use of specialized Claude Code agents.

## Changes
- Added "Agent Team" section to `AGENTS.md` with agent references and usage encouragement
- Lists all 6 specialized agents: code-reviewer, docs-synchronizer, senior-developer, system-architect, test-strategist, validation-engineer
- Promotes agent utilization with "If you have access use agents, do it\!" guidance

## Context
Complements the agent setup in `.claude/agents/` by updating the main project documentation to reference the new capabilities.

## Test plan
- [ ] Verify documentation formatting and links
- [ ] Confirm agent references match actual agent files